### PR TITLE
Bugfix: can match constructors starting with "d"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /stamp-h1
 .dep
 Makefile.in
+build
 /configure
 /aclocal.m4
 *~

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -82,7 +82,8 @@ Expr *call_run_code(Expr *code) {
   return computed_result;
 }
 
-char our_getc_c = 0;
+int our_getc_buf_size = 0;
+char our_getc_buf[OUR_GETC_BUF_CAPACITY];
 
 int IDBUF_LEN = 2048;
 char idbuf[2048];

--- a/src/check.h
+++ b/src/check.h
@@ -16,6 +16,8 @@
 #include <map>
 #include <cstddef>
 
+#define OUR_GETC_BUF_CAPACITY 16
+
 // see the help message in main.cpp for explanation
 typedef struct args {
   std::vector<std::string> files;
@@ -39,7 +41,8 @@ void check_file(const char *_filename, args a, sccwriter* scw = NULL, libwriter*
 
 void cleanup();
 
-extern char our_getc_c;
+extern int our_getc_buf_size;
+extern char our_getc_buf[OUR_GETC_BUF_CAPACITY];
 
 void report_error(const std::string &);
 
@@ -49,9 +52,10 @@ extern const char *filename;
 extern FILE *curfile;
 
 inline void our_ungetc(char c) {
-  if (our_getc_c != 0)
+  if (our_getc_buf_size >= OUR_GETC_BUF_CAPACITY)
     report_error("Internal error: our_ungetc buffer full");
-  our_getc_c = c;
+  our_getc_buf[our_getc_buf_size] = c;
+  our_getc_buf_size += 1;
   if (c == '\n') {
     linenum--;
     colnum=-1;
@@ -62,9 +66,9 @@ inline void our_ungetc(char c) {
 
 inline char our_getc() {
   char c;
-  if (our_getc_c > 0) {
-    c = our_getc_c;
-    our_getc_c = 0;
+  if (our_getc_buf_size > 0) {
+    our_getc_buf_size -= 1;
+    c = our_getc_buf[our_getc_buf_size];
   }
   else{
 #ifndef __linux__

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -7,6 +7,12 @@
 
 using namespace std;
 
+// Tries to pull `str` out of the character stream
+// If it fails, returns an (owned) string representing what was pulled from the
+// string, a prefix of `str`.
+// If it succeeds, returns null.
+//
+// If `check_end` is set, verifies that the word ends after what was parsed.
 string *eat_str(const char *str, bool check_end = true) {
   string *s = new string();
   char c, d;
@@ -94,9 +100,22 @@ Expr *read_case() {
   }
   // default case
   case 'd': {
-    delete eat_str("efault");
-  }
+    our_ungetc('d');
+    string * already_read = eat_str("default");
+    if ( already_read != nullptr ) {
+      // Put the parts of "default" that we read back into the token stream so
+      // they can be reparsed
+      for (auto i = already_read->crbegin(); i != already_read->crend(); ++i) {
+          our_ungetc(*i);
+      }
+      // Could be an id
+      pat = read_ctor();
+      delete already_read;
+    } else {
+      // Success! This is `default`
+    }
     break;
+  }
   case EOF:
     report_error("Unexpected end of file parsing a pattern.");
     break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ static void parse_args(int argc, char **argv, args &a)
       cout << "--compile-scc-debug: compile debug versions of side condition code\n"; 
       cout << "--run-scc: use compiled side condition code\n"; 
       exit(0);
-    }	  
+    }
     else if(strcmp("--show-runs", *argv) == 0) {
       argc--; argv++;
       a.show_runs = true;


### PR DESCRIPTION
Summary
---

   * constructors which start with "d" can now be pattern matched
     against.
   * the character stream now supports re-insertion of ~~1~~ **16**
     characters via the `our_ungetc` function.

Detail
---

Before if you had a constructor for a data-type that started with a "d",
like the `dn` null element and `dc` cons element for the list type `list`
below, then attempts to pattern match against the constructor would
result in an unknown identifier error.

Thus simple programs like this one could not be type-checked:
```
; Declare an item type
(declare item type)

; Declare a list type with null and cons constructors
(declare list type)
(declare dn list)
(declare dc (! i item (! r list list)))

; Returns the length of a list
(program length ((l list)) mpz
         (match l
                ; ERROR: "n" is unknown!?
                (dn 0)
                ; ERROR: "c" is unknown!?
                ((dc i l') (mp_add 1 (length l')))))
```

The cause of this was some poorly-planned code paths in the part of the
parser that detects `default` cases in a `match` expression.

In fixing the bug I expanded the character stream buffer so that we
could put multiple items back into the stream.

Testing
---

I tested the fix by
   1. verifying that the test program above now type-checks.
   2. verifying that many signatures from CVC4 still check out, by
      running this command (zsh): `/path/to/lfscc /path/to/CVC4/proofs/signatures/{sat.plf,smt.plf,th_base.plf,th_bv.plf,th_bv_bitblast.plf,th_arrays.plf,th_int.plf,th_quant.plf}`
      * I got that list of theories from Yoni -- those are the thoeries
      he **always** loads with LFSC, but its not gauranteed to be
      exhaustive -- if I should test with others, let me know.