### PR TITLE
Bugfix in application parsing

### DIFF
--- a/src/code.cpp
+++ b/src/code.cpp
@@ -452,6 +452,7 @@ Expr *read_code() {
 	              pref = new string("mp_");
 	              break;
 	            }
+                    break;
             }
             default:
               our_ungetc(c);


### PR DESCRIPTION
Some applications that began with mp_ but were not arithmetic built-ins
were being miss-parsed. The problem was a missing break statment in a
case block...

This program used to fail to _parse_:
```
(run (mp_sub 4 4))
```

And now it doesn't.

I tested by reconfiguring CVC4, rebuilding it, and running `make check`. This change shouldn't affect any  valid programs anyway.