### PR TITLE
Bugfix: side condition C++ generation

### DIFF
--- a/src/sccwriter.cpp
+++ b/src/sccwriter.cpp
@@ -965,6 +965,9 @@ void sccwriter::write_expr(
     ss2 << ss.str().c_str();
     write_code(code, os, ind, ss2.str().c_str(), opts);
 
+    expr = std::string(ss.str().c_str());
+    vars.push_back(expr);
+
     // if is not a sym expression, then decrement the expression and return null
     if (opts & opt_write_check_sym_expr)
     {
@@ -976,9 +979,6 @@ void sccwriter::write_expr(
       indent(os, ind);
       os << "}" << std::endl;
     }
-
-    expr = std::string(ss.str().c_str());
-    vars.push_back(expr);
   }
   // increment the counter for memory management
   // indent( os, ind );


### PR DESCRIPTION
The SC generation code was using a string before it could be populated.

Notice the use of `expr` on line 975 (after diff).

This cause compiled side-condition code to occasionally be invalid because the check being generated here ended up looking like

```
if (->getclass() != SYM_EXPR) { // notice the missing identifier!
  exit( 1 );
}
```

Now the problem is fixed.

I tested this by
1. generating compiled SCs for all the CVC4 signatures (including the un-merge DRAT signature) 
2. re-compiling LFSC
3. checking a sample bitvector proof using `--run-scc`.

Really, step 2 was enough to verify correctness.