### PR TITLE
Bugfix: Parser

### DIFF
--- a/src/code.cpp
+++ b/src/code.cpp
@@ -350,6 +350,7 @@ Expr *read_code()
                   pref = new string("ma");
                   break;
               }
+              break;
             }
             case 'p':
             {


### PR DESCRIPTION
There was (another) missing break statement in the parser which caused
the application of functions beginning with `mar` to be miss-parsed,
unless they were an invocation of `markvar`.

This is no longer the case.

Since this is a just parser modification, I tested by running LFSC on all of CVC4's signatures, including a signature containing a function application of the offending variety. I then used LFSC to check a proof using that signature.