### PR TITLE
Bugfix: Free variable check

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -689,6 +689,7 @@ bool Expr::_free_in(Expr *x, expr_ptr_set_t *visited)
           return (s == x);
         }
         case INT_EXPR: return false;
+        case RAT_EXPR: return false;
       }
       break;
     case LAM:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(lfsc_test_file_list
   th_int.plf
   use-bool.plf
   use-use-bool.plf
+  unused_pi_param_rational_in_body.plf
 )
 
 set(test_script ${CMAKE_CURRENT_LIST_DIR}/run_test.py)

--- a/tests/tests/unused_pi_param_rational_in_body.plf
+++ b/tests/tests/unused_pi_param_rational_in_body.plf
@@ -1,0 +1,8 @@
+(declare value type)
+(declare variable type)
+(declare assignment_witness (! v variable (! val value type)))
+
+(declare rational_predicate (! r mpq type))
+
+(declare (! v value (! var variable (! a (assignment_witness var v) (rational_predicate 1/1)))))
+


### PR DESCRIPTION
There was a weird bug where PI bindings with rationals in their body could sometimes cause aborts.

Properly, these conditions are sufficient to generate the bug:
   * A PI binding
   * with an unused parameter
   * with a rational in the body

 and the root cause was that the `_free_in` function, which determines whether some name is free in an expression, didn't know how to handle rationals.

This root cause indicates that the bug would also occur if the parameter were free, but if a rational occurred on the search path before any of the parameter's reference sites.

Added a test to prevent regressions.