### PR TITLE
Bugfix: rational printing

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -792,8 +792,6 @@ void Expr::print(ostream &os)
         case RAT_EXPR:
         {
           RatExpr *e = (RatExpr *)this;
-          char *s = mpq_get_str(0, 10, e->n);
-          os << s;
           if (mpq_sgn(e->n) < 0)
           {
             os << "(~ ";


### PR DESCRIPTION
Our code for printing out rationals was a bit odd. For positive
rationals it would print them twice, so the value `3` would be printed
as `33`, and `4/5` would be `4/54/5`.

For negative rationals it would print the number in standard format,
followed by the number in ~-negation format, so `-2` would be printed as
`-2(~ 2)`.

The core cause was that we had code that just printed rationals, and
code that case-split on the sign  and did fancy stuff like ~, and **we
ran both pieces of code**.

Also fixes a tiny memory leak.