### PR TITLE
Bar semicolons from identifiers

### DIFF
--- a/src/check.h
+++ b/src/check.h
@@ -129,7 +129,7 @@ inline const char *prefix_id()
 {
   int i = 0;
   char c = idbuf[i++] = non_ws();
-  while (!isspace(c) && c != '(' && c != ')' && c != char(EOF))
+  while (!isspace(c) && c != '(' && c != ')' && c != ';' && c != char(EOF))
   {
     if (i == IDBUF_LEN) report_error("Identifier is too long");
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(lfsc_test_file_list
   use-bool.plf
   use-use-bool.plf
   unused_pi_param_rational_in_body.plf
+  semicolon_after_id.plf
 )
 
 set(test_script ${CMAKE_CURRENT_LIST_DIR}/run_test.py)

--- a/tests/tests/semicolon_after_id.plf
+++ b/tests/tests/semicolon_after_id.plf
@@ -1,0 +1,11 @@
+; Deps: sat.plf
+
+
+(check
+  (% cheat (holds cln)
+     (: (holds cln)
+        cheat; hi
+     )
+  )
+)
+


### PR DESCRIPTION
Before, a sequence like

      myIdent;

would parse as the identifier "myIdent;".

I would argue that the ";" is the start of a comment, so the identifier
should be "myIdent".

This is fixed now.

I also added a test for this situation.