### PR TITLE
Add support for checking streams instead of files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,5 +15,5 @@ BraceWrapping:
   BeforeCatch: true
   BeforeElse: true
 BreakBeforeBraces: Custom
+DerivePointerAlignment: false
 ...
-

--- a/src/check.h
+++ b/src/check.h
@@ -12,6 +12,7 @@
 #endif
 
 #include <cstddef>
+#include <iosfwd>
 #include <map>
 #include <stack>
 #include <string>
@@ -41,6 +42,12 @@ void check_file(const char *_filename,
                 sccwriter *scw = NULL,
                 libwriter *lw = NULL);
 
+void check_file(std::istream& in,
+                const std::string& filename,
+                args a,
+                sccwriter* scw = NULL,
+                libwriter* lw = NULL);
+
 void cleanup();
 
 extern char our_getc_c;
@@ -50,7 +57,7 @@ void report_error(const std::string &);
 extern int linenum;
 extern int colnum;
 extern const char *filename;
-extern FILE *curfile;
+extern std::istream* curfile;
 
 inline void our_ungetc(char c)
 {
@@ -75,11 +82,7 @@ inline char our_getc()
   }
   else
   {
-#ifndef __linux__
-    c = fgetc(curfile);
-#else
-    c = fgetc_unlocked(curfile);
-#endif
+    c = curfile->get();
   }
   switch (c)
   {
@@ -89,7 +92,7 @@ inline char our_getc()
 #endif
       colnum = 1;
       break;
-    case char(EOF): break;
+    case std::istream::traits_type::eof(): break;
     default: colnum++;
   }
 
@@ -105,7 +108,7 @@ inline char non_ws()
   if (c == ';')
   {
     // comment to end of line
-    while ((c = our_getc()) != '\n' && c != char(EOF))
+    while ((c = our_getc()) != '\n' && c != std::istream::traits_type::eof())
       ;
     return non_ws();
   }

--- a/src/lfscc.cpp
+++ b/src/lfscc.cpp
@@ -6,6 +6,28 @@
 
 void lfscc_init(void) { init(); }
 
+void lfscc_check_file(const char* filename,
+                      bool show_runs,
+                      bool no_tail_calls,
+                      bool compile_scc,
+                      bool compile_scc_debug,
+                      bool run_scc,
+                      bool use_nested_app,
+                      bool compile_lib,
+                      sccwriter* scw,
+                      libwriter* lw)
+{
+  args a;
+  a.show_runs = show_runs;
+  a.no_tail_calls = no_tail_calls;
+  a.compile_scc = compile_scc;
+  a.compile_scc_debug = compile_scc_debug;
+  a.run_scc = run_scc;
+  a.use_nested_app = use_nested_app;
+  a.compile_lib = compile_lib;
+  check_file(filename, a, scw, lw);
+}
+
 void lfscc_check_file(std::istream& in,
                       bool show_runs,
                       bool no_tail_calls,

--- a/src/lfscc.cpp
+++ b/src/lfscc.cpp
@@ -1,9 +1,12 @@
+#include <fstream>
+#include <iostream>
+
 #include "lfscc.h"
 #include "check.h"
 
 void lfscc_init(void) { init(); }
 
-void lfscc_check_file(const char* filename,
+void lfscc_check_file(std::istream& in,
                       bool show_runs,
                       bool no_tail_calls,
                       bool compile_scc,
@@ -22,7 +25,8 @@ void lfscc_check_file(const char* filename,
   a.run_scc = run_scc;
   a.use_nested_app = use_nested_app;
   a.compile_lib = compile_lib;
-  check_file(filename, a, scw, lw);
+  std::string filename("<stream>");
+  check_file(in, filename, a, scw, lw);
 }
 
 void lfscc_cleanup(void) { cleanup(); }

--- a/src/lfscc.h
+++ b/src/lfscc.h
@@ -9,7 +9,7 @@ class libwriter;
 
 void lfscc_init();
 
-void lfscc_check_file(const char* filename,
+void lfscc_check_file(std::istream& in,
                       bool show_runs,
                       bool no_tail_calls,
                       bool compile_scc,

--- a/src/lfscc.h
+++ b/src/lfscc.h
@@ -9,6 +9,17 @@ class libwriter;
 
 void lfscc_init();
 
+void lfscc_check_file(const char* filename,
+                      bool show_runs,
+                      bool no_tail_calls,
+                      bool compile_scc,
+                      bool compile_scc_debug,
+                      bool run_scc,
+                      bool use_nested_app,
+                      bool compile_lib,
+                      sccwriter* scw = NULL,
+                      libwriter* lw = NULL);
+
 void lfscc_check_file(std::istream& in,
                       bool show_runs,
                       bool no_tail_calls,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,11 +123,9 @@ int main(int argc, char **argv)
       lw = new libwriter;
     }
     /* process the files named */
-    int i = 0, iend = a.files.size();
-    for (; i < iend; i++)
+    for (const std::string& file : a.files)
     {
-      const char *filename = a.files[i].c_str();
-      check_file(filename, a, scw, lw);
+      check_file(file.c_str(), a, scw, lw);
     }
     if (scw)
     {


### PR DESCRIPTION
This commit adds a variant of `check_file()` that takes an
`std::istream` instead of a file name. This allows proof checking
without creating temporary files. There are lots of opportunities for
cleaning up the code. However, this commit aims to introduce the feature
without changing the original code too much. Cleanup will follow in a
future commit.

One minor additional change: It changes the Clang-Format file to not try
to not use the most common alignment of `&` and `*` because otherwise
our formatting for LFSC is different from the one used in CVC4.