### PR TITLE
 Check side condition return type

### DIFF
--- a/src/check.cpp
+++ b/src/check.cpp
@@ -1318,7 +1318,7 @@ void check_file(std::istream& in,
           statType->inc();
           int prev = open_parens;
           // read the return type of the program
-          Expr *progtpret = check(true, statType, &tmp, 0, true);
+          Expr* progtpret = check(true, statType, &tmp, 0, true);
           eat_excess(prev);
 
           if (!progtpret->isDatatype())
@@ -1329,7 +1329,7 @@ void check_file(std::istream& in,
           Expr *progcode = read_code();
 
           // now, construct the type of the program
-          Expr *progtp = progtpret;
+          Expr* progtp = progtpret;
           for (int i = vars.size() - 1, iend = 0; i >= iend; i--)
           {
             vars[i]->inc();  // used below for the program code (progcode)
@@ -1341,18 +1341,17 @@ void check_file(std::istream& in,
           // 0.
           prog->val = new CExpr(PROG, progtp);
 
-          Expr *rettp = check_code(progcode);
+          Expr* rettp = check_code(progcode);
 
           // check that the body matches the return type
-          if( !rettp->defeq(progtpret) )
+          if (!rettp->defeq(progtpret))
           {
-            report_error(string("Return type for a program does not match")
-                         + string(" its body.\n1. the type: ")
-                         + rettp->toString()
-                         + string("\n2. the expected type: ")
-                         + progtpret->toString());
+            report_error(
+                string("Return type for a program does not match")
+                + string(" its body.\n1. the type: ") + rettp->toString()
+                + string("\n2. the expected type: ") + progtpret->toString());
           }
-          
+
           progcode =
               new CExpr(PROG, progtp, new CExpr(PROGVARS, vars), progcode);
           // if compiling side condition code, give this code to the side

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -1317,16 +1317,19 @@ void check_file(std::istream& in,
 
           statType->inc();
           int prev = open_parens;
-          Expr *progtp = check(true, statType, &tmp, 0, true);
+          // read the return type of the program
+          Expr *progtpret = check(true, statType, &tmp, 0, true);
           eat_excess(prev);
 
-          if (!progtp->isDatatype())
+          if (!progtpret->isDatatype())
             report_error(string("Return type for a program is not a")
                          + string(" datatype.\n1. the type: ")
-                         + progtp->toString());
+                         + progtpret->toString());
 
           Expr *progcode = read_code();
 
+          // now, construct the type of the program
+          Expr *progtp = progtpret;
           for (int i = vars.size() - 1, iend = 0; i >= iend; i--)
           {
             vars[i]->inc();  // used below for the program code (progcode)
@@ -1338,8 +1341,18 @@ void check_file(std::istream& in,
           // 0.
           prog->val = new CExpr(PROG, progtp);
 
-          check_code(progcode);
+          Expr *rettp = check_code(progcode);
 
+          // check that the body matches the return type
+          if( !rettp->defeq(progtpret) )
+          {
+            report_error(string("Return type for a program does not match")
+                         + string(" its body.\n1. the type: ")
+                         + rettp->toString()
+                         + string("\n2. the expected type: ")
+                         + progtpret->toString());
+          }
+          
           progcode =
               new CExpr(PROG, progtp, new CExpr(PROGVARS, vars), progcode);
           // if compiling side condition code, give this code to the side

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -844,7 +844,6 @@ Expr *check_code(Expr *_e)
 
       SymSExpr *tp1 = (SymSExpr *)check_code(e->kids[1]);
       SymSExpr *tp2 = (SymSExpr *)check_code(e->kids[2]);
-      std::cout << tp1->getclass() << " != " << SYMS_EXPR << " " << tp1->val << " " << tp1 << " != " << tp2 << std::endl;
       if (tp1->getclass() != SYMS_EXPR || tp1->val || tp1 != tp2)
         report_error(
             string("\"mp_if\" used with expressions that do not ")

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -844,6 +844,7 @@ Expr *check_code(Expr *_e)
 
       SymSExpr *tp1 = (SymSExpr *)check_code(e->kids[1]);
       SymSExpr *tp2 = (SymSExpr *)check_code(e->kids[2]);
+      std::cout << tp1->getclass() << " != " << SYMS_EXPR << " " << tp1->val << " " << tp1 << " != " << tp2 << std::endl;
       if (tp1->getclass() != SYMS_EXPR || tp1->val || tp1 != tp2)
         report_error(
             string("\"mp_if\" used with expressions that do not ")


### PR DESCRIPTION
This ensures we check that the return type of side conditions matches the body of the side condition.

Unfortunately I don't think there a test I can add to exercise this fix (since this would require infrastructure for testing failing LFSC tests).