### PR TITLE
Expand definitions for arithmetic terms in side conditions

### DIFF
--- a/src/code.cpp
+++ b/src/code.cpp
@@ -802,7 +802,8 @@ Expr *check_code(Expr *_e)
     {
       Expr *tp0 = check_code(e->kids[0]);
       Expr *tp1 = check_code(e->kids[1]);
-
+      tp0 = tp0->followDefs();
+      tp1 = tp1->followDefs();
       if (tp0 != statMpz && tp0 != statMpq)
         report_error(string("Argument to mp_[arith] does not have type \"mpz\" "
                             "or \"mpq\".\n")
@@ -822,6 +823,7 @@ Expr *check_code(Expr *_e)
     case NEG:
     {
       Expr *tp0 = check_code(e->kids[0]);
+      tp0 = tp0->followDefs();
       if (tp0 != statMpz && tp0 != statMpq)
         report_error(
             string(
@@ -836,6 +838,7 @@ Expr *check_code(Expr *_e)
     case IFZERO:
     {
       Expr *tp0 = check_code(e->kids[0]);
+      tp0 = tp0->followDefs();
       if (tp0 != statMpz && tp0 != statMpq)
         report_error(
             string("Argument to mp_if does not have type \"mpz\" or \"mpq\".\n")

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -723,7 +723,7 @@ Expr *check_code(Expr *_e)
               + string("\n2. its (functional) type: ") + cur->toString());
         if (argtps[i]->getop() == APP)
           argtps[i] = ((CExpr *)argtps[i])->kids[0];
-        if (argtps[i] != cur->kids[1])
+        if (!argtps[i]->defeq(cur->kids[1]))
         {
           char buf[1024];
           sprintf(buf, "%d", i);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(lfsc_test_file_list
   bool.plf
   mp_prefix.plf
+  num.plf
   sat.plf
   smt.plf
   th_arrays.plf

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(lfsc_test_file_list
   bool.plf
+  issue8-mpexp.plf
   mp_prefix.plf
+  mp_smaller_test.plf
   num.plf
   sat.plf
   smt.plf

--- a/tests/tests/issue8-mpexp.plf
+++ b/tests/tests/issue8-mpexp.plf
@@ -1,0 +1,9 @@
+(program f' ((i mpz)) mpz
+         (mp_mul i 3))
+
+(define myint mpz)
+
+(program g ((i myint)) mpz i) ; Works
+
+(program f ((i myint)) myint
+         (mp_mul i 3)) ; "Expected type 'mpz', got type 'mpz'" !?!?

--- a/tests/tests/mp_smaller_test.plf
+++ b/tests/tests/mp_smaller_test.plf
@@ -1,0 +1,25 @@
+(declare bool type)
+(declare tt bool)
+(declare ff bool)
+
+(define num mpz)
+
+(program mp_smaller ((m mpz) (n mpz)) bool
+  (mp_ifneg (mp_add m (mp_neg n)) tt ff)
+)  
+
+(program smaller ((m num) (n num)) bool
+  (mp_smaller m n)
+)
+
+(declare checked_smaller
+  (! x mpz (! y mpz type)))
+
+(declare check_smaller
+  (! x mpz
+  (! y mpz
+  (! u (^ (smaller x y) tt)
+    (checked_smaller x y))))))
+
+(check
+  (: (checked_smaller 5 6) (check_smaller 5 6)))

--- a/tests/tests/num.plf
+++ b/tests/tests/num.plf
@@ -1,0 +1,9 @@
+(define num mpz)
+
+(program p1 ((e1 num)) num
+  1
+)
+
+(program p2 ((e1 num) (e2 num)) num
+  (mp_add e1 e2)
+)


### PR DESCRIPTION
We previously had spurious failures due to not recognizing when a symbol was defined to be the integer type.