### PR TITLE
 Fix error checking for ifequal

### DIFF
--- a/src/code.cpp
+++ b/src/code.cpp
@@ -983,7 +983,6 @@ Expr *check_code(Expr *_e)
             + string("\n2. second expression: ") + e->kids[1]->toString()
             + string("\n3. first expression's type: ") + tp0->toString()
             + string("\n4. second expression's type: ") + tp1->toString());
-        report_error(errstr1);
       }
 
       SymSExpr *tpc1 = (SymSExpr *)check_code(e->kids[2]);

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -972,25 +972,17 @@ Expr *check_code(Expr *_e)
     case IFEQUAL:
     {
       SymSExpr *tp0 = (SymSExpr *)check_code(e->kids[0]);
-      if (tp0->getclass() != SYMS_EXPR || tp0->val)
-      {
-        string errstr0 =
-            (string("\"ifequal\" is used with a first expression which ")
-             + string("cannot be a lambda-bound variable.\n")
-             + string("1. the expression :") + e->kids[0]->toString()
-             + string("\n2. its type: ") + tp0->toString());
-        report_error(errstr0);
-      }
-
       SymSExpr *tp1 = (SymSExpr *)check_code(e->kids[1]);
 
-      if (tp1->getclass() != SYMS_EXPR || tp1->val)
+      if (tp0!=tp1)
       {
-        string errstr1 =
-            (string("\"ifequal\" is used with a second expression which ")
-             + string("cannot be a lambda-bound variable.\n")
-             + string("1. the expression :") + e->kids[1]->toString()
-             + string("\n2. its type: ") + tp1->toString());
+        report_error(
+            string("\"ifequal\" used with compare expressions that do not ")
+            + string("have equal types\n")
+            + string("\n1. first expression: ") + e->kids[0]->toString()
+            + string("\n2. second expression: ") + e->kids[1]->toString()
+            + string("\n3. first expression's type: ") + tp0->toString()
+            + string("\n4. second expression's type: ") + tp1->toString());
         report_error(errstr1);
       }
 
@@ -998,10 +990,10 @@ Expr *check_code(Expr *_e)
       SymSExpr *tpc2 = (SymSExpr *)check_code(e->kids[3]);
       if (tpc1->getclass() != SYMS_EXPR || tpc1->val || tpc1 != tpc2)
         report_error(
-            string("\"ifequal\" used with expressions that do not ")
+            string("\"ifequal\" used with return expressions that do not ")
             + string("have equal simple datatypes\nfor their types.\n")
-            + string("\n1. first expression: ") + e->kids[3]->toString()
-            + string("\n2. second expression: ") + e->kids[4]->toString()
+            + string("\n1. first expression: ") + e->kids[2]->toString()
+            + string("\n2. second expression: ") + e->kids[3]->toString()
             + string("\n3. first expression's type: ") + tpc1->toString()
             + string("\n4. second expression's type: ") + tpc2->toString());
       return tpc1;

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -974,15 +974,15 @@ Expr *check_code(Expr *_e)
       SymSExpr *tp0 = (SymSExpr *)check_code(e->kids[0]);
       SymSExpr *tp1 = (SymSExpr *)check_code(e->kids[1]);
 
-      if (tp0!=tp1)
+      if (tp0 != tp1)
       {
         report_error(
             string("\"ifequal\" used with compare expressions that do not ")
-            + string("have equal types\n")
-            + string("\n1. first expression: ") + e->kids[0]->toString()
-            + string("\n2. second expression: ") + e->kids[1]->toString()
-            + string("\n3. first expression's type: ") + tp0->toString()
-            + string("\n4. second expression's type: ") + tp1->toString());
+            + string("have equal types\n") + string("\n1. first expression: ")
+            + e->kids[0]->toString() + string("\n2. second expression: ")
+            + e->kids[1]->toString() + string("\n3. first expression's type: ")
+            + tp0->toString() + string("\n4. second expression's type: ")
+            + tp1->toString());
       }
 
       SymSExpr *tpc1 = (SymSExpr *)check_code(e->kids[2]);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(lfsc_test_file_list
   bool.plf
+  eq_mpz.plf
   mp_prefix.plf
   sat.plf
   smt.plf

--- a/tests/tests/eq_mpz.plf
+++ b/tests/tests/eq_mpz.plf
@@ -5,3 +5,16 @@
 
 (program eq_mpz ((x mpz) (y mpz) (b bool)) bool
   (ifequal x y tt ff))
+
+(declare checked_mpz
+  (! b mpz type))
+
+(declare check_eq_mqz
+  (! x mpz
+  (! y mpz
+  (! b bool
+  (! u (^ (eq_mpz x y b) tt)
+    (checked_mpz x))))))
+
+(check
+  (: (checked_mpz 5) (check_eq_mqz 5 5 tt)))

--- a/tests/tests/eq_mpz.plf
+++ b/tests/tests/eq_mpz.plf
@@ -1,0 +1,7 @@
+(declare bool type)
+(declare tt bool)
+(declare ff bool)
+
+
+(program eq_mpz ((x mpz) (y mpz) (b bool)) bool
+  (ifequal x y tt ff))


### PR DESCRIPTION
The error check for ifequal was too strict; it was insisting that the condition values (`a` and `b` in `(ifequal a b t1 t2)`) were simple types when it could have allowed e.g. integer types.

This also ensures that the types of the two condition values are the same.