### PR TITLE
Fix parsing of identifiers at head of application

### DIFF
--- a/src/check.h
+++ b/src/check.h
@@ -128,10 +128,17 @@ inline void eat_char(char expected)
 extern int IDBUF_LEN;
 extern char idbuf[];
 
-inline const char *prefix_id()
+/**
+ * Parses an identifier.
+ *
+ * @param skip_ws If true, skips the whitespace before the identifier. Expects
+ * the identifier to start at the current position otherwise.
+ * @return Pointer to the buffer holding the identifier string
+ */
+inline const char *prefix_id(bool skip_ws = true)
 {
   int i = 0;
-  char c = idbuf[i++] = non_ws();
+  char c = idbuf[i++] = skip_ws ? non_ws() : our_getc();
   while (!isspace(c) && c != '(' && c != ')' && c != ';' && c != char(EOF))
   {
     if (i == IDBUF_LEN) report_error("Identifier is too long");

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -535,10 +535,18 @@ Expr *read_code()
       }
       // parse application
       if (pref)
-        // we have eaten part of the name of an applied identifier
-        pref->append(prefix_id());
+      {
+        // We have eaten part of the name (or all) of an applied identifier. We
+        // parse the rest of the identifier and append it. Note: we don't want
+        // `prefix_id()` to skip whitespace, otherwise we may accidentially
+        // parse the next identifier (if `pref` already holds the complete
+        // identifier) and add it to the current one.
+        pref->append(prefix_id(false));
+      }
       else
+      {
         pref = new string(prefix_id());
+      }
 
       Expr *ret = progs[*pref];
       if (!ret)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,17 +1,18 @@
 set(lfsc_test_file_list
   bool.plf
+  issue20.plf
   mp_prefix.plf
   sat.plf
+  semicolon_after_id.plf
   smt.plf
   th_arrays.plf
   th_base.plf
-  th_bv_bitblast.plf
   th_bv.plf
+  th_bv_bitblast.plf
   th_int.plf
+  unused_pi_param_rational_in_body.plf
   use-bool.plf
   use-use-bool.plf
-  unused_pi_param_rational_in_body.plf
-  semicolon_after_id.plf
 )
 
 set(test_script ${CMAKE_CURRENT_LIST_DIR}/run_test.py)

--- a/tests/tests/issue20.plf
+++ b/tests/tests/issue20.plf
@@ -1,0 +1,12 @@
+(declare comparison type)
+(declare SMALLER comparison)
+(declare EQUAL comparison)
+(declare GREATER comparison)
+
+(program compar ((m mpz) (n mpz)) comparison
+  EQUAL
+)
+
+(program p1 ((x mpz) (y mpz)) comparison
+  (compar x y)
+)


### PR DESCRIPTION
Fixes #20. When parsing the identifier at the head of an application, we
try to match it against reserved words such as `compare`. When this
matching fails, we have a prefix of an identifier that is also a prefix
of a reserved word, e.g. if our identifier is `compfoo` we have `comp`,
and we need to parse the rest of the identifier. If it happened that our
identifier is just a prefix of a reserved word, e.g. `compar`, then we'd
try to parse the rest of the identifier using `prefix_id()`, which skips
whitespace before an identifier and we ended up parsing the next
identifier as the suffix of the current identifier. This commit fixes
the issue by adding an argument to `prefix_id()` that determines whether
to skip whitespaces before an identifier or not. While this fixes the
issue, I intend to refactor the parsing code to first parse the complete
identifier and then to try matching it against known identifiers. This
would simplify the code and could even end up being slightly faster.