### PR TITLE
Throw error when too few arguments are provided for match pattern

### DIFF
--- a/src/code.cpp
+++ b/src/code.cpp
@@ -1038,6 +1038,14 @@ Expr *check_code(Expr *_e)
 #endif
               curtp = (CExpr *)((CExpr *)(curtp->followDefs()))->kids[2];
             }
+            // if we have not consumed enough pattern arguments
+            if (curtp->followDefs()->getop() == PI)
+            {
+              report_error(
+                  string("Too few arguments to a constructor in")
+                  + string(" a pattern.\n1. the pattern: ") + pat->toString()
+                  + string("\n2. the head's type: " + ctortp->toString()));
+            }
 
             tp = check_code(c->kids[1]);
 


### PR DESCRIPTION
We were previously segfaulting while running code with too few arguments in a pattern.  Here is an example of a problem where we previously segfaulted but now throw the error message introduced in this PR:

```

(declare bool type)
(declare tt bool)
(declare ff bool)

; Concept type
(declare concept type)
(declare top concept)
(declare bot concept)
(declare inter (! x concept (! y concept concept)))

(program test ((c concept)) bool
    (match c
      (top tt)
      (bot ff)
      ((inter c1) tt)
      ))

(declare holds (! c concept type))

(declare run_test (! c concept
                  (! sc (^ (test c) tt)  
  (holds c)
))))


(check 
  (: (holds (inter top top)) (run_test (inter top top))))
```