### PR TITLE
Implemented a built-in function: mpz_to_mpq

### DIFF
--- a/src/code.cpp
+++ b/src/code.cpp
@@ -320,131 +320,149 @@ Expr *read_code()
             }
             case 'p':
             {
-              our_ungetc('p');
-              pref = eat_str("p_", false);
-              if (pref)
-              {
-                pref->insert(0, "m");
-                break;
-              }
-              char c = our_getc();
-              switch (c)
-              {
-                case 'a':
+              char cc = our_getc();
+              switch (cc) {
+                case '_':
                 {
-                  our_ungetc('a');
-                  pref = eat_str("add");
-                  if (pref)
-                  {
-                    pref->insert(0, "mp_");
-                    break;
-                  }
-                  Expr *e1 = read_code();
-                  Expr *e2 = read_code();
-                  Expr *ret = new CExpr(ADD, e1, e2);
-                  eat_char(')');
-                  return ret;
-                }
-                case 'n':
-                {
-                  our_ungetc('n');
-                  pref = eat_str("neg");
-                  if (pref)
-                  {
-                    pref->insert(0, "mp_");
-                    break;
-                  }
-
-                  Expr *ret = new CExpr(NEG, read_code());
-                  eat_char(')');
-                  return ret;
-                }
-                case 'i':
-                {  // mpz_if_neg
                   char c = our_getc();
-                  if (c == 'f')
+                  switch (c)
                   {
-                    c = our_getc();
-                    switch (c)
+                    case 'a':
                     {
-                      case 'n':
+                      our_ungetc('a');
+                      pref = eat_str("add");
+                      if (pref)
                       {
-                        our_ungetc('n');
-                        pref = eat_str("neg");
-                        if (pref)
-                        {
-                          pref->insert(0, "mp_if");
-                          break;
-                        }
-                        Expr *e1 = read_code();
-                        Expr *e2 = read_code();
-                        Expr *e3 = read_code();
-                        Expr *ret = new CExpr(IFNEG, e1, e2, e3);
-                        eat_char(')');
-                        return ret;
-                      }
-                      case 'z':
-                      {
-                        our_ungetc('z');
-                        pref = eat_str("zero");
-                        if (pref)
-                        {
-                          pref->insert(0, "mp_if");
-                          break;
-                        }
-                        Expr *e1 = read_code();
-                        Expr *e2 = read_code();
-                        Expr *e3 = read_code();
-                        Expr *ret = new CExpr(IFZERO, e1, e2, e3);
-                        eat_char(')');
-                        return ret;
-                      }
-                      default:
-                        our_ungetc(c);
-                        pref = new string("mp_if");
+                        pref->insert(0, "mp_");
                         break;
+                      }
+                      Expr *e1 = read_code();
+                      Expr *e2 = read_code();
+                      Expr *ret = new CExpr(ADD, e1, e2);
+                      eat_char(')');
+                      return ret;
                     }
+                    case 'n':
+                    {
+                      our_ungetc('n');
+                      pref = eat_str("neg");
+                      if (pref)
+                      {
+                        pref->insert(0, "mp_");
+                        break;
+                      }
+
+                      Expr *ret = new CExpr(NEG, read_code());
+                      eat_char(')');
+                      return ret;
+                    }
+                    case 'i':
+                    {  // mpz_if_neg
+                      char c = our_getc();
+                      if (c == 'f')
+                      {
+                        c = our_getc();
+                        switch (c)
+                        {
+                          case 'n':
+                          {
+                            our_ungetc('n');
+                            pref = eat_str("neg");
+                            if (pref)
+                            {
+                              pref->insert(0, "mp_if");
+                              break;
+                            }
+                            Expr *e1 = read_code();
+                            Expr *e2 = read_code();
+                            Expr *e3 = read_code();
+                            Expr *ret = new CExpr(IFNEG, e1, e2, e3);
+                            eat_char(')');
+                            return ret;
+                          }
+                          case 'z':
+                          {
+                            our_ungetc('z');
+                            pref = eat_str("zero");
+                            if (pref)
+                            {
+                              pref->insert(0, "mp_if");
+                              break;
+                            }
+                            Expr *e1 = read_code();
+                            Expr *e2 = read_code();
+                            Expr *e3 = read_code();
+                            Expr *ret = new CExpr(IFZERO, e1, e2, e3);
+                            eat_char(')');
+                            return ret;
+                          }
+                          default:
+                            our_ungetc(c);
+                            pref = new string("mp_if");
+                            break;
+                        }
+                      }
+                      else
+                      {
+                        our_ungetc(c);
+                        pref = new string("mp_i");
+                        break;
+                      }
+                    }
+                    case 'm':
+                    {
+                      our_ungetc('m');
+                      pref = eat_str("mul");
+                      if (pref)
+                      {
+                        pref->insert(0, "mp_");
+                        break;
+                      }
+                      Expr *e1 = read_code();
+                      Expr *e2 = read_code();
+                      Expr *ret = new CExpr(MUL, e1, e2);
+                      eat_char(')');
+                      return ret;
+                    }
+                    case 'd':
+                    {
+                      our_ungetc('d');
+                      pref = eat_str("div");
+                      if (pref)
+                      {
+                        pref->insert(0, "mp_");
+                        break;
+                      }
+                      Expr *e1 = read_code();
+                      Expr *e2 = read_code();
+                      Expr *ret = new CExpr(DIV, e1, e2);
+                      eat_char(')');
+                      return ret;
+                    }
+                    default:
+                      our_ungetc(c);
+                      pref = new string("mp_");
+                      break;
                   }
-                  else
-                  {
-                    our_ungetc(c);
-                    pref = new string("mp_i");
-                    break;
-                  }
+                  break;
                 }
-                case 'm':
+                case 'z':
                 {
-                  our_ungetc('m');
-                  pref = eat_str("mul");
+                  our_ungetc('z');
+                  pref = eat_str("z_to_mpq", true);
                   if (pref)
                   {
-                    pref->insert(0, "mp_");
+                    pref->insert(0, "mp");
                     break;
                   }
-                  Expr *e1 = read_code();
-                  Expr *e2 = read_code();
-                  Expr *ret = new CExpr(MUL, e1, e2);
-                  eat_char(')');
-                  return ret;
-                }
-                case 'd':
-                {
-                  our_ungetc('d');
-                  pref = eat_str("div");
-                  if (pref)
-                  {
-                    pref->insert(0, "mp_");
-                    break;
-                  }
-                  Expr *e1 = read_code();
-                  Expr *e2 = read_code();
-                  Expr *ret = new CExpr(DIV, e1, e2);
+                  Expr* e = read_code();
+                  Expr* ret = new CExpr(RAT_CAST, e);
                   eat_char(')');
                   return ret;
                 }
                 default:
-                  our_ungetc(c);
-                  pref = new string("mp_");
+                  our_ungetc(cc);
+                  pref = new string("mp");
                   break;
               }
               break;
@@ -764,6 +782,20 @@ Expr *check_code(Expr *_e)
             + string("\n1. its type: ") + tp0->toString());
 
       return tp0;
+    }
+
+    case RAT_CAST:
+    {
+      Expr *tp0 = check_code(e->kids[0]);
+      tp0 = tp0->followDefs();
+      if (tp0 != statMpz)
+        report_error(
+            string(
+                "Argument to mpz_to_mpq does not have type \"mpz\".\n")
+            + string("1. the argument: ") + e->kids[0]->toString()
+            + string("\n1. its type: ") + tp0->toString());
+
+      return statMpq;
     }
 
     case IFNEG:
@@ -1168,6 +1200,15 @@ start_run_code:
         r1->dec();
         return NULL;
       }
+    }
+    case RAT_CAST:
+    {
+      Expr *r1 = run_code(e->kids[0]);
+      if (!r1) return NULL;
+      mpq_t r;
+      mpq_init(r);
+      mpq_set_num(r, ((IntExpr *)r1)->n);
+      return new RatExpr(r);
     }
     case IFNEG:
     case IFZERO:

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -456,7 +456,7 @@ Expr *read_code()
                     break;
                   }
                   Expr* e = read_code();
-                  Expr* ret = new CExpr(RAT_CAST, e);
+                  Expr* ret = new CExpr(MPZ_TO_MPQ, e);
                   eat_char(')');
                   return ret;
                 }
@@ -784,7 +784,7 @@ Expr *check_code(Expr *_e)
       return tp0;
     }
 
-    case RAT_CAST:
+    case MPZ_TO_MPQ:
     {
       Expr *tp0 = check_code(e->kids[0]);
       tp0 = tp0->followDefs();
@@ -1201,7 +1201,7 @@ start_run_code:
         return NULL;
       }
     }
-    case RAT_CAST:
+    case MPZ_TO_MPQ:
     {
       Expr *r1 = run_code(e->kids[0]);
       if (!r1) return NULL;

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -923,7 +923,7 @@ void Expr::print(ostream &os)
       print_kids(os, e->kids);
       os << ")";
       break;
-    case RAT_CAST:
+    case MPZ_TO_MPQ:
       os << "(mpz_to_mpq";
       print_kids(os, e->kids);
       os << ")";

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -923,6 +923,11 @@ void Expr::print(ostream &os)
       print_kids(os, e->kids);
       os << ")";
       break;
+    case RAT_CAST:
+      os << "(mpz_to_mpq";
+      print_kids(os, e->kids);
+      os << ")";
+      break;
     case IFNEG:
       os << "(ifneg";
       print_kids(os, e->kids);

--- a/src/expr.h
+++ b/src/expr.h
@@ -50,6 +50,7 @@ enum
   NEG,
   IFNEG,
   IFZERO,
+  RAT_CAST,
   LET,
   RUN,
   FAIL,

--- a/src/expr.h
+++ b/src/expr.h
@@ -50,7 +50,7 @@ enum
   NEG,
   IFNEG,
   IFZERO,
-  RAT_CAST,
+  MPZ_TO_MPQ,
   LET,
   RUN,
   FAIL,

--- a/src/sccwriter.cpp
+++ b/src/sccwriter.cpp
@@ -766,6 +766,28 @@ void sccwriter::write_code(
           write_dec(expr1, os, ind);
         }
         break;
+        case RAT_CAST:
+        {
+          // calculate the value for the first expression
+          std::string expr1;
+          write_expr(((CExpr*)code)->kids[0], os, ind, expr1);
+          std::ostringstream ss;
+          ss << "rnum" << rnumCount;
+          rnumCount++;
+          indent(os, ind);
+          os << "mpq_t " << ss.str().c_str() << ";" << std::endl;
+          indent(os, ind);
+          os << "mpq_init(" << ss.str().c_str() << ");" << std::endl;
+          indent(os, ind);
+          os << "mpq_set_num( " << ss.str().c_str() << ", ((IntExpr*)"
+             << expr1.c_str() << "->followDefs())->n );" << std::endl;
+          indent(os, ind);
+          os << retModString.c_str() << "new RatExpr(" << ss.str().c_str()
+             << ");" << std::endl;
+          // clean up memory
+          write_dec(expr1, os, ind);
+        }
+        break;
         case IFNEG:
         case IFZERO:
         {

--- a/src/sccwriter.cpp
+++ b/src/sccwriter.cpp
@@ -766,7 +766,7 @@ void sccwriter::write_code(
           write_dec(expr1, os, ind);
         }
         break;
-        case RAT_CAST:
+        case MPZ_TO_MPQ:
         {
           // calculate the value for the first expression
           std::string expr1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,8 @@ set(lfsc_test_file_list
   issue8-mpexp.plf
   mp_prefix.plf
   mp_smaller_test.plf
+  mpz_to_mpq.plf
+  mpz_to_mpq_checks.plf
   num.plf
   sat.plf
   semicolon_after_id.plf

--- a/tests/tests/mpz_to_mpq.plf
+++ b/tests/tests/mpz_to_mpq.plf
@@ -1,0 +1,26 @@
+; Deps: bool.plf
+(program convert ((z mpz)) mpq
+         (mpz_to_mpq z))
+
+(program is_floor ((f mpz) (x mpq)) bool
+         (mp_ifneg (mp_add x (mp_neg (mpz_to_mpq f)))
+                   ff
+                   (mp_ifneg (mp_add x (mp_neg (mpz_to_mpq (mp_add f 1))))
+                             tt
+                             ff)))
+
+; Check that various other names do not get mis-parsed
+(program mpz_to_mpqq ((z mpz)) mpz
+         z)
+(program mp_to_mpq ((z mpz)) mpz
+         z)
+(program mpz_to_mp ((z mpz)) mpz
+         z)
+(program mp_z_to_mpq ((z mpz)) mpz
+         z)
+
+(program id ((z mpz)) mpz
+         (mpz_to_mpqq
+           (mp_to_mpq
+             (mpz_to_mp
+               (mp_z_to_mpq z)))))

--- a/tests/tests/mpz_to_mpq_checks.plf
+++ b/tests/tests/mpz_to_mpq_checks.plf
@@ -1,0 +1,31 @@
+; Deps: mpz_to_mpq.plf
+(declare checked_convert
+  (! x mpz
+  (! y mpq type)))
+(declare check_convert
+  (! x mpz
+  (! y mpq
+    (! u (^ (convert x) y)
+      (checked_convert x y)))))
+
+(check
+  (: (checked_convert 1 1/1) (check_convert 1 1/1)))
+(check
+  (: (checked_convert (~ 2) (~ 2/1)) (check_convert (~ 2) (~ 2/1))))
+(check
+  (: (checked_convert 10 10/1) (check_convert 10 10/1)))
+
+(declare checked_is_floor
+  (! x mpz
+  (! y mpq
+     type)))
+(declare check_is_floor
+  (! x mpz
+  (! y mpq
+    (! u (^ (is_floor x y) tt)
+      (checked_is_floor x y)))))
+
+(check
+  (: (checked_is_floor 1 1/1) (check_is_floor 1 1/1)))
+(check
+  (: (checked_is_floor 1 3/2) (check_is_floor 1 3/2)))


### PR DESCRIPTION
This function converts from integers to rationals.

Without it, we actually had no way to do this, since our mp functions
all insist that children have the same type.

Involves the following changes:
   * Define a new operator, `MPZ_TO_MPQ`.
   * Modify `read_code` to parse it.
      * This is actually quite simple, but requires changing the
      indentation of a bunch of existing code, so the diff is large.
   * Modify `check_code` to check it.
   * Modify `run_code` to run it.
   * Modify `print` to print it.
   * Add tests that use it.
      * These tests are run automatically by the CI testing.
   * Modify `write_code` to generate C++ from it.
      * SC compilation is not tested by the CI testing, but I tested
      this manually.