### PR TITLE
Better output on test failure

### DIFF
--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -109,7 +109,7 @@ def main():
     if 0 != code:
         stdout = result.stdout.read()
         if stdout:
-            print(stdout)
+            print(stdout.decode())
     return code
 
 if __name__ == '__main__':


### PR DESCRIPTION
Before, we ran LFSC on the test and if there was an error, printed out
the `stdout` member from the CompletedProcess object.

That member is acutally a byte array, so it didn't print very nicely.
For example, newlines printed as '\n', instead of as newlines.

Now we decode (as UTF-8) the bytes before printing them.

This produces nicer output.