### PR TITLE
Always print rationals with "/"

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1,4 +1,4 @@
-#include "expr.h"
+#include <gmp.h>
 #include <stdlib.h>
 #include <cstddef>
 #include <sstream>
@@ -767,23 +767,35 @@ void Expr::print(ostream &os)
         case RAT_EXPR:
         {
           RatExpr *e = (RatExpr *)this;
+          mpq_t tmp;
+          mpq_init(tmp);
+
           if (mpq_sgn(e->n) < 0)
           {
             os << "(~ ";
-            mpq_t tmp;
-            mpq_init(tmp);
             mpq_neg(tmp, e->n);
-            char *s = mpq_get_str(0, 10, tmp);
-            os << s;
-            free(s);
-            mpq_clear(tmp);
-            os << ")";
           }
           else
           {
-            char *s = mpq_get_str(0, 10, e->n);
-            os << s;
-            free(s);
+            mpq_set(tmp, e->n);
+          }
+
+          mpz_t tmp_num;
+          mpz_init(tmp_num);
+          mpq_get_num(tmp_num, tmp);
+          char *s = mpz_get_str(0, 10, tmp_num);
+          os << s << "/";
+          free(s);
+
+          mpz_t tmp_denom;
+          mpz_init(tmp_denom);
+          mpq_get_den(tmp_denom, tmp);
+          s = mpz_get_str(0, 10, tmp_denom);
+          os << s;
+          free(s);
+
+          if (mpq_sgn(e->n) < 0) {
+            os << ")";
           }
           break;
         }

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -1,4 +1,4 @@
-#include <gmp.h>
+#include "expr.h"
 #include <stdlib.h>
 #include <cstddef>
 #include <sstream>


### PR DESCRIPTION
We were using gmp to print rationals LFSC expressions.

gmp omits the slash if the denominator is 1.

However, LFSC requires that the slash is always there.

This commit fixes the problem, by printing the slash manually.