### PR TITLE
type-checker allows all proper types as pgm args

### DIFF
--- a/src/check.cpp
+++ b/src/check.cpp
@@ -1189,14 +1189,15 @@ void check_file(std::istream& in,
             statType->inc();
             int prev = open_parens;
             Expr *tp = check(true, NULL, &tmp, 0, true);
-            Expr *kind = compute_kind(tp);
+            Expr* kind = compute_kind(tp);
             if (kind != statType && !tp->isDatatype())
             {
-                report_error(string("A program argument's type is neither proper, nor a datatype.")
-                             + string("\n1. the type: ")
-                             + tp->toString()
-                             + string("\n2. its kind: ")
-                             + (kind == nullptr ? string("none") : kind->toString()));
+              report_error(
+                  string("A program argument's type is neither proper, nor a "
+                         "datatype.")
+                  + string("\n1. the type: ") + tp->toString()
+                  + string("\n2. its kind: ")
+                  + (kind == nullptr ? string("none") : kind->toString()));
             }
             eat_excess(prev);
 
@@ -1216,11 +1217,12 @@ void check_file(std::istream& in,
           Expr* kind = compute_kind(progtpret);
           if (kind != statType && !progtpret->isDatatype())
           {
-                report_error(string("A program's return type is neither proper, nor a datatype.")
-                             + string("\n1. the type: ")
-                             + progtpret->toString()
-                             + string("\n2. its kind: ")
-                             + (kind == nullptr ? string("none") : kind->toString()));
+            report_error(
+                string("A program's return type is neither proper, nor a "
+                       "datatype.")
+                + string("\n1. the type: ") + progtpret->toString()
+                + string("\n2. its kind: ")
+                + (kind == nullptr ? string("none") : kind->toString()));
           }
 
           Expr *progcode = read_code();
@@ -1360,80 +1362,78 @@ Expr* compute_kind(Expr* e)
   e = e->followDefs();
   switch (e->getclass())
   {
-    case CEXPR:
-    {
-      CExpr* ce = static_cast<CExpr *>(e);
+    case CEXPR: {
+      CExpr* ce = static_cast<CExpr*>(e);
       switch (e->getop())
       {
-        case APP:
-        {
-          Expr * head = compute_kind(ce->kids[0]);
-          std::vector<std::pair<SymExpr *, Expr *>> prev_pi_vars_and_values;
+        case APP: {
+          Expr* head = compute_kind(ce->kids[0]);
+          std::vector<std::pair<SymExpr*, Expr*>> prev_pi_vars_and_values;
           size_t next_kid_i = 1;
-          for (;
-               head->getop() == PI && ce->kids[next_kid_i] != nullptr;
-               ++next_kid_i) {
-            Expr * actual_arg = ce->kids[next_kid_i]->followDefs();
-            CExpr * pi = static_cast<CExpr *>(head);
-            Expr * range = pi->kids[2];
-            SymExpr *pi_var = static_cast<SymExpr *>(pi->kids[0]);
-            prev_pi_vars_and_values.push_back(std::make_pair(pi_var, pi_var->val));
+          for (; head->getop() == PI && ce->kids[next_kid_i] != nullptr;
+               ++next_kid_i)
+          {
+            Expr* actual_arg = ce->kids[next_kid_i]->followDefs();
+            CExpr* pi = static_cast<CExpr*>(head);
+            Expr* range = pi->kids[2];
+            SymExpr* pi_var = static_cast<SymExpr*>(pi->kids[0]);
+            prev_pi_vars_and_values.push_back(
+                std::make_pair(pi_var, pi_var->val));
             pi_var->val = actual_arg;
             head = compute_kind(range);
           }
-          if (ce->kids[next_kid_i] != nullptr && head->getop() != PI) {
-            // We're not holding a function anymore, but there are more arguments!
+          if (ce->kids[next_kid_i] != nullptr && head->getop() != PI)
+          {
+            // We're not holding a function anymore, but there are more
+            // arguments!
             report_error(string("When reducing ") + e->toString()
                          + string(" I got the expression ") + head->toString()
                          + string(" applied to some arguments, but that "
                                   "expression is not a function"));
           }
-          for (const auto & p : prev_pi_vars_and_values) {
+          for (const auto& p : prev_pi_vars_and_values)
+          {
             p.first->val = p.second;
           }
           return head;
         }
         case MPQ:
-        case MPZ:
-        {
+        case MPZ: {
           return statType;
         }
-        default:
-        {
+        default: {
           return e;
         }
       }
     }
     case SYMS_EXPR:
-    case SYM_EXPR:
-    {
-      Expr * reference = e->followDefs();
-      if (reference->getclass() == SYMS_EXPR) {
-        auto ref_value_and_type = symbols->get(static_cast<SymSExpr *>(reference)->s.c_str());
-        if (ref_value_and_type.second != nullptr) {
+    case SYM_EXPR: {
+      Expr* reference = e->followDefs();
+      if (reference->getclass() == SYMS_EXPR)
+      {
+        auto ref_value_and_type =
+            symbols->get(static_cast<SymSExpr*>(reference)->s.c_str());
+        if (ref_value_and_type.second != nullptr)
+        {
           reference = ref_value_and_type.second;
         }
       }
       return reference;
     }
     case RAT_EXPR:
-    case INT_EXPR:
-    {
+    case INT_EXPR: {
       return e;
     }
-    case HOLE_EXPR:
-    {
+    case HOLE_EXPR: {
       report_error("Hole expression have no kind.");
-      return nullptr; // unreachable
+      return nullptr;  // unreachable
     }
-    default:
-    {
+    default: {
       report_error("Unknown expression class in compute_kind()");
-      return nullptr; // unreachable
+      return nullptr;  // unreachable
     }
   }
 }
-
 
 void init()
 {

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -1357,6 +1357,7 @@ void cleanup()
 
 Expr* compute_kind(Expr* e)
 {
+  e = e->followDefs();
   switch (e->getclass())
   {
     case CEXPR:
@@ -1372,7 +1373,7 @@ Expr* compute_kind(Expr* e)
           for (;
                head->getop() == PI && ce->kids[next_kid_i] != nullptr;
                ++next_kid_i) {
-            Expr * actual_arg = compute_kind(ce->kids[next_kid_i]);
+            Expr * actual_arg = ce->kids[next_kid_i]->followDefs();
             CExpr * pi = static_cast<CExpr *>(head);
             Expr * range = pi->kids[2];
             SymExpr *pi_var = static_cast<SymExpr *>(pi->kids[0]);
@@ -1413,11 +1414,7 @@ Expr* compute_kind(Expr* e)
           reference = ref_value_and_type.second;
         }
       }
-      if (reference == e) {
-        return e;
-      } else {
-        return compute_kind(reference);
-      }
+      return reference;
     }
     case RAT_EXPR:
     case INT_EXPR:
@@ -1431,7 +1428,7 @@ Expr* compute_kind(Expr* e)
     }
     default:
     {
-      report_error("Unkown expression class in compute_kind()");
+      report_error("Unknown expression class in compute_kind()");
       return nullptr; // unreachable
     }
   }

--- a/src/check.h
+++ b/src/check.h
@@ -192,6 +192,34 @@ extern Expr *statType;
  * Given a type, `e`, computes its kind.
  *
  * In particular, this will be `statType` if the kind is that of proper types.
+ *
+ * Since our system doen't draw a clear distinction between kinding and typing,
+ * this function doesn't either. It could also be regarded as a function that
+ * computes the type of a term. While values technically have no kind, this
+ * function would return their type instead of an error.
+ *
+ * It is different from "check" in that it computes the kind/type of in-memory
+ * terms, not serialized ones.
+ *
+ * Given these declarations:
+ *
+ *     (declare bool type)
+ *     (declare sort type)
+ *     (declare Real sort)
+ *     (declare term (! s sort type))
+ *
+ * Examples of proper types:
+ *
+ *     bool
+ *     sort
+ *     (term Real)
+ *
+ * Example of non-proper types:
+ *
+ *   * term (it has kind `(! s sort type)`)
+ *   * Real (it is not a type, and does not have a kind)
+ *          (this function would return `sort`)
+ *
  */
 Expr* compute_kind(Expr* e);
 

--- a/src/check.h
+++ b/src/check.h
@@ -188,4 +188,11 @@ extern Expr *statMpz;
 extern Expr *statMpq;
 extern Expr *statType;
 
+/**
+ * Given a type, `e`, computes its kind.
+ *
+ * In particular, this will be `statType` if the kind is that of proper types.
+ */
+Expr* compute_kind(Expr* e);
+
 #endif

--- a/src/check.h
+++ b/src/check.h
@@ -220,6 +220,8 @@ extern Expr *statType;
  *   * Real (it is not a type, and does not have a kind)
  *          (this function would return `sort`)
  *
+ * Bibliography:
+ *   * _Advanced Topics in Types and Programming Languages_
  */
 Expr* compute_kind(Expr* e);
 

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -962,7 +962,7 @@ Expr *check_code(Expr *_e)
       Expr *kind = compute_kind(scruttp);
       if (kind != statType && !scruttp->isDatatype())
       {
-          report_error(string("The match scrutinee's type is neither proper, nor a datatypes")
+          report_error(string("The match scrutinee's type is neither proper, nor a datatype")
                        + string("\n1. the type: ")
                        + scruttp->toString()
                        + string("\n2. its kind: ")

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -684,10 +684,10 @@ Expr *check_code(Expr *_e)
               string("A function is not being fully applied in code.\n")
               + string("1. the application: ") + e->toString()
               + string("\n2. its (functional) type: ") + cur->toString());
-        bool types_match =
-          argtps[i]->defeq(cur->kids[1]);
+        bool types_match = argtps[i]->defeq(cur->kids[1]);
         bool app_types_match =
-          argtps[i]->getop() == APP && static_cast<CExpr *>(argtps[i])->kids[0]->defeq(cur->kids[1]);
+            argtps[i]->getop() == APP
+            && static_cast<CExpr*>(argtps[i])->kids[0]->defeq(cur->kids[1]);
         if (!types_match && !app_types_match)
         {
           report_error(
@@ -959,14 +959,15 @@ Expr *check_code(Expr *_e)
     case MATCH:
     {
       SymSExpr *scruttp = (SymSExpr *)check_code(e->kids[0]);
-      Expr *kind = compute_kind(scruttp);
+      Expr* kind = compute_kind(scruttp);
       if (kind != statType && !scruttp->isDatatype())
       {
-          report_error(string("The match scrutinee's type is neither proper, nor a datatype")
-                       + string("\n1. the type: ")
-                       + scruttp->toString()
-                       + string("\n2. its kind: ")
-                       + (kind == nullptr ? string("none") : kind->toString()));
+        report_error(
+            string(
+                "The match scrutinee's type is neither proper, nor a datatype")
+            + string("\n1. the type: ") + scruttp->toString()
+            + string("\n2. its kind: ")
+            + (kind == nullptr ? string("none") : kind->toString()));
       }
 
       int i = 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(lfsc_test_file_list
   eq_mpz.plf
   issue20.plf
   issue8-mpexp.plf
+  formal_type_args.plf
   mp_prefix.plf
   mp_smaller_test.plf
   mpz_to_mpq.plf
@@ -17,6 +18,7 @@ set(lfsc_test_file_list
   th_bv.plf
   th_bv_bitblast.plf
   th_int.plf
+  th_quant.plf
   unused_pi_param_rational_in_body.plf
   use-bool.plf
   use-use-bool.plf

--- a/tests/tests/formal_type_args.plf
+++ b/tests/tests/formal_type_args.plf
@@ -1,0 +1,14 @@
+(declare sort type)
+(declare term (! s sort type))
+
+(declare Real sort)
+
+(declare var type)
+(declare real_var (! v var (term Real)))
+(declare real_lit (! v mpq (term Real)))
+(declare +_Real (! a (term Real) (! b (term Real) (term Real))))
+
+(program reverse ((t (term Real))) (term Real)
+         (match t
+                ((+_Real a b) (+_Real (reverse b) (reverse a)))
+                (default t)))

--- a/tests/tests/th_quant.plf
+++ b/tests/tests/th_quant.plf
@@ -1,0 +1,81 @@
+; Deps: smt.plf th_base.plf
+(declare forall (! s sort
+                   (! t (term s)
+                      (! f formula
+                         formula))))
+
+;This program recursively checks the instantiation.
+;Composite terms (such as "apply _ _ ...") are handled recursively.
+;Then, if ti and t are equal, we return true. Otherwise, we first verify that t is the variable for which ti is substitued (ifmarked). if this is the case, ti should be equal to k.
+
+(program is_inst_t ((ti term) (t term) (k term)) bool
+         (match t
+                ((apply s1 s2 t1 t2)
+                 (match ti
+                        ((apply si1 si2 ti1 ti2)
+                         (match (is_inst_t ti1 t1 k) (tt (is_inst_t ti2 t2 k)) (ff ff)))
+                        (default ff)))
+                (default (ifequal ti t tt (ifmarked t (ifequal ti k tt ff) ff)))))
+
+
+(program is_inst_f ((fi formula) (f formula) (k term)) bool
+         (match f
+                ((and f1 f2) (match fi
+                                    ((and fi1 fi2) (match (is_inst_f fi1 f1 k) (tt (is_inst_f fi2 f2 k)) (ff ff)))
+                                    (default ff)))
+                ((or f1 f2) (match fi
+                                   ((or fi1 fi2) (match (is_inst_f fi1 f1 k) (tt (is_inst_f fi2 f2 k)) (ff ff)))
+                                   (default ff)))
+                ((impl f1 f2) (match fi
+                                     ((impl fi1 fi2) (match (is_inst_f fi1 f1 k) (tt (is_inst_f fi2 f2 k)) (ff ff)))
+                                     (default ff)))
+                ((not f1) (match fi
+                                 ((not fi1) (is_inst_f fi1 f1 k))
+                                 (default ff)))
+                ((iff f1 f2) (match fi
+                                    ((iff fi1 fi2) (match (is_inst_f fi1 f1 k) (tt (is_inst_f fi2 f2 k)) (ff ff)))
+                                    (default ff)))
+                ((xor f1 f2) (match fi
+                                    ((xor fi1 fi2) (match (is_inst_f fi1 f1 k) (tt (is_inst_f fi2 f2 k)) (ff ff)))
+                                    (default ff)))
+                ((ifte f1 f2 f3) (match fi
+                                        ((ifte fi1 fi2 fi3) (match (is_inst_f fi1 f1 k)
+                                                                   (tt (match (is_inst_f fi2 f2 k) (tt (is_inst_f fi3 f3 k)) (ff ff)))
+                                                                   (ff ff)))
+                                        (default ff)))
+                ((= s t1 t2) (match fi
+                                    ((= s ti1 ti2) (match (is_inst_t ti1 t1 k) (tt (is_inst_t ti2 t2 k)) (ff ff)))
+                                    (default ff)))
+                ((forall s t1 f1) (match fi
+                                         ((forall s ti1 fi1) (is_inst_f fi1 f1 k))
+                                         (default ff)))
+                (default ff)))
+
+(program is_inst ((fi formula) (f formula) (t term) (k term)) bool
+         (do (markvar t)
+           (let f1 (is_inst_f fi f k)
+             (do (markvar t) f1))))
+
+(declare skolem
+         (! s sort
+            (! t (term s)
+               (! f formula
+                  (! p (th_holds (not (forall s t f)))
+                     (! u (! k (term s)
+                             (! fi formula
+                                (! p1 (th_holds (not fi))
+                                   (! r (^ (is_inst fi f t k) tt)
+                                      (holds cln)))))
+                        (holds cln)))))))
+
+(declare inst
+         (! s sort
+            (! t (term s)
+               (! f formula
+                  (! k (term s)
+                     (! fi formula
+                        (! p (th_holds (forall s t f))
+                           (! r (^ (is_inst fi f t k) tt)
+                              (! u (! p1 (th_holds fi)
+                                      (holds cln))
+                                 (holds cln))))))))))


### PR DESCRIPTION
LFSC side conditions have argument types and return types.

Originally our type checker required these to by symbols that were
declared as types, or as functions to types.

This PR implements the following rule: any proper type can be the
argument of a program argument. This is a good rule, because it
keeps the dependent typing out of the side-conditions, but allows for
all reasonable, introspectable data to be handled in SCs.

To allow for the kind of program's found in the theory of quantifiers,
we continue to allow functions to types to be given as the type of a
parameter, and to be matched agaist. We'd like to adopt a more
principled approach to these kinds of programs, but that is orthogonal
to this change.

Implementation:
   * A function `compute_kind`.
   * Allow program argument types, return types, and match scrutinee
   types for which `compute_kind` returns `statType`. (i.e. proper
   types).
   * Adds test cases for
      * th_quant.plf
      * programs that take (term Real)
   * Fixes a random signed/unsigned comparison warning (on my compiler)