### PR TITLE
Replace deprecated __gnu_cxx::hash_map with std::unordered_map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 add_cxx_flag("-Wall")
-add_cxx_flag("-Wno-deprecated")
 add_cxx_flag("-std=gnu++11")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -33,7 +33,7 @@ std::vector<Expr *> ascHoles;
 
 Trie<pair<Expr *, Expr *> > *symbols = new Trie<pair<Expr *, Expr *> >;
 
-hash_map<string, bool> imports;
+std::unordered_map<string, bool> imports;
 std::map<SymExpr *, int> mark_map;
 std::vector<std::pair<std::string, std::pair<Expr *, Expr *> > >
     local_sym_names;

--- a/src/check.h
+++ b/src/check.h
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <hash_map>
 #else
-#include <ext/hash_map>
+#include <unordered_map>
 #endif
 
 #include <cstddef>
@@ -158,8 +158,8 @@ inline const char *prefix_id(bool skip_ws = true)
 typedef std::hash_map<std::string, Expr *> symmap;
 typedef std::hash_map<std::string, SymExpr *> symmap2;
 #else
-typedef __gnu_cxx::hash_map<std::string, Expr *> symmap;
-typedef __gnu_cxx::hash_map<std::string, SymExpr *> symmap2;
+typedef std::unordered_map<std::string, Expr *> symmap;
+typedef std::unordered_map<std::string, SymExpr *> symmap2;
 #endif
 extern symmap2 progs;
 extern std::vector<Expr *> ascHoles;
@@ -170,19 +170,6 @@ extern std::map<SymExpr *, int> mark_map;
 
 extern std::vector<std::pair<std::string, std::pair<Expr *, Expr *> > >
     local_sym_names;
-
-#ifndef _MSC_VER
-namespace __gnu_cxx {
-template <>
-struct hash<std::string>
-{
-  size_t operator()(const std::string &x) const
-  {
-    return hash<const char *>()(x.c_str());
-  }
-};
-}  // namespace __gnu_cxx
-#endif
 
 extern Expr *statMpz;
 extern Expr *statMpq;


### PR DESCRIPTION
Additionally remove -Wno-deprecated, since hash_map is the only deprecated interface currently in use.  Note that std::unordered_map is part of the C++11 standard, and CMakeLists.txt already requires a C++11 compiler.