### PR TITLE
 Use LAM values rather than PI values for #-form

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,5 +39,5 @@ jobs:
       run: make -j2
       working-directory: build
     - name: Test
-      run: make test
+      run: ctest --output-on-failure
       working-directory: build

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -231,13 +231,31 @@ start_check:
           eat_rparen();
           CExpr *tmp = new CExpr(PI, sym, domain, rec_computed);
           tmp->calc_free_in();
+          if(tmp->get_free_in()) {
+            std::ostringstream o;
+            o << "The type of an annotated lambda is dependent."
+              << "\n1. The type    : ";
+            tmp->print(o);
+            o << "\n2. The variable: ";
+            sym->print(o);
+            o << "\n3. The body    : ";
+            range->print(o);
+            report_error(o.str());
+          }
+          // Since `sym` is the SymSExpr used inside the *value* of this
+          // Lambda, having it also be in the type would cause type-checking
+          // bindings to change the value.
+          //
+          // We change the type's symbol to avoid this.
+          tmp->kids[0] = new SymSExpr(id);
           *computed = static_cast<Expr*>(tmp);
 
           symbols->insert(id.c_str(), prev);
           if (create)
           {
-            CExpr *ret = new CExpr(PI, sym, domain, range);
-            ret->calc_free_in();
+            CExpr *ret = new CExpr(LAM, sym, range);
+            // Mark this as "cloned" to block no-clone optimization
+            ret->setcloned();
             return ret;
           }
           return 0;

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -231,7 +231,8 @@ start_check:
           eat_rparen();
           CExpr *tmp = new CExpr(PI, sym, domain, rec_computed);
           tmp->calc_free_in();
-          if(tmp->get_free_in()) {
+          if (tmp->get_free_in())
+          {
             std::ostringstream o;
             o << "The type of an annotated lambda is dependent."
               << "\n1. The type    : ";
@@ -253,7 +254,7 @@ start_check:
           symbols->insert(id.c_str(), prev);
           if (create)
           {
-            CExpr *ret = new CExpr(LAM, sym, range);
+            CExpr* ret = new CExpr(LAM, sym, range);
             // Mark this as "cloned" to block no-clone optimization
             ret->setcloned();
             return ret;

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -159,7 +159,7 @@ Expr *Expr::clone()
           var->val = newvar;
           Expr *bod = e->kids[1]->clone();
           var->val = prev;
-          CExpr * r = new CExpr(LAM, newvar, bod);
+          CExpr* r = new CExpr(LAM, newvar, bod);
           // Lambdas which have `cloned` set should never have the no-clone
           // optimization applied, even after cloning. Propagate this.
           if (e->cloned())

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -159,7 +159,14 @@ Expr *Expr::clone()
           var->val = newvar;
           Expr *bod = e->kids[1]->clone();
           var->val = prev;
-          return new CExpr(LAM, newvar, bod);
+          CExpr * r = new CExpr(LAM, newvar, bod);
+          // Lambdas which have `cloned` set should never have the no-clone
+          // optimization applied, even after cloning. Propagate this.
+          if (e->cloned())
+          {
+            r->setcloned();
+          }
+          return r;
         }
         case PI: {
 #ifdef DEBUG_SYM_NAMES

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -4,6 +4,7 @@ import re
 import os.path
 import sys
 import subprocess
+import resource
 
 class TestConfiguration(object):
     ''' Represents a test to run.  '''
@@ -101,12 +102,15 @@ class TestFile(object):
         self.config_map = m
 
 def main():
+    # Units: bytes
+    resource.setrlimit(resource.RLIMIT_STACK, (2**25, resource.RLIM_INFINITY))
     configuration = TestConfiguration()
     cmd = [configuration.lfscc] + configuration.dep_graph.getPathsInOrder()
     print('Command: ', cmd)
     result = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
     (stdout, _) = result.communicate()
     if 0 != result.returncode:
+        print(f"Exited with code {result.returncode}")
         if stdout:
             print(stdout.decode())
     return result.returncode

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -110,7 +110,7 @@ def main():
     result = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
     (stdout, _) = result.communicate()
     if 0 != result.returncode:
-        print(f"Exited with code {result.returncode}")
+        print("Exited with code {}".format(result.returncode))
         if stdout:
             print(stdout.decode())
     return result.returncode


### PR DESCRIPTION
# Use LAM values rather than PI values for #-form

Additionally, use different symbols for the abstraction variables in the
type and value associated with a #-form.

Additionally, force the lambda value for a #-form to be cloned when
necessary (e.g. during weak-head-reduction, or during implicit
weak-head-reduction during stream-checking.

This fixes a class of bugs related to #-forms in which different
applications of the same form would interfere with each other and not be
properly applied during type-checking.

A file illustrating one of the bugs, from @yoni206:
* [strange2.plf](https://github.com/yoni206/CVC4/blob/pf_uf_sigs/proofs/new/proofs/strange2.plf)

The root cause of these bugs is three-fold:
* LFSC does not apply weak-head-reduction to PI-values. I believe it
  should, but it suffices for us to use LAM-values in this instance.
* Using the same symbol for the abstraction variable in both the *value*
  and *type* of a #-form causes the abstraction-bindings created during
  type-checking to modify other terms in the system (those dependent) on
  the #-form's value in subtle and wrong ways.
* I don't fully understand the invariants that LFSC's no-clone WHR
  optimization relies on, but those invariants seem to be invalidated by
  the LAM-values we're creating here, so I've disabled that optimization
  for them.

