### PR TITLE
Functions for checking for unbound variables.

### DIFF
--- a/src/check.cpp
+++ b/src/check.cpp
@@ -1379,6 +1379,21 @@ Expr* compute_kind(Expr* e)
   }
 }
 
+void assert_all_vars_bound(Expr* e)
+{
+  Expr* unbound = e->find_unbound_vars(symbols);
+  if (unbound)
+  {
+    std::ostringstream o;
+    o << "In the expression:\n\t";
+    e->print(o);
+    o << "\nthe symbol\n\t";
+    unbound->print(o);
+    o << "\nis unbound\n";
+    report_error(o.str());
+  }
+}
+
 void init()
 {
   symbols->insert("type", pair<Expr*, Expr*>(statType, statKind));

--- a/src/check.h
+++ b/src/check.h
@@ -125,4 +125,6 @@ extern Expr *statType;
  */
 Expr* compute_kind(Expr* e);
 
+void assert_all_vars_bound(Expr* e);
+
 #endif

--- a/src/expr.h
+++ b/src/expr.h
@@ -10,6 +10,7 @@
 
 #include "chunking_memory_management.h"
 #include "gmp.h"
+#include "trie.h"
 
 #define DEBUG_SYM_NAMES
 //#define DEBUG_SYMS
@@ -196,6 +197,14 @@ class Expr
      holes in e.  We do not take responsibility for the reference to
      this nor the reference to e. */
   bool defeq(Expr *e);
+
+  /* Checks whether all variables (SymExprs and SymSExprs) are either (a) bound
+   * by a binder in the expression or (b) in the provided trie.
+   *
+   * If so, returns nullptr.
+   * If not, returns a pointer to the unbound variable.
+   */
+  Expr* find_unbound_vars(Trie<std::pair<Expr*, Expr*> >* symbols);
 
   /* return a clone of this expr.  All abstractions are really duplicated
      in memory.  Other expressions may not actually be duplicated in


### PR DESCRIPTION
I found these useful when debugging the LAM/PI/weak-head-reduction bug.
I figure they may be useful again in the future.