### PR TITLE
Apply weak-head-reduction in match.

### DIFF
--- a/src/code.cpp
+++ b/src/code.cpp
@@ -1059,7 +1059,13 @@ start_run_code:
       // Apply WHR to c-expressions, otherwise you don't really know the head.
       if (scrut->getclass() == CEXPR)
       {
-        scrut = static_cast<CExpr*>(scrut)->whr();
+        Expr *tmp = static_cast<CExpr*>(scrut)->whr();
+        // If a new expression is returned, dec the old RC
+        if (tmp != scrut)
+        {
+          scrut->dec();
+          scrut = tmp;
+        }
       }
       vector<Expr *> args;
       Expr *hd = scrut->collect_args(args);

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -1056,6 +1056,11 @@ start_run_code:
     {
       Expr *scrut = run_code(e->kids[0]);
       if (!scrut) return 0;
+      // Apply WHR to c-expressions, otherwise you don't really know the head.
+      if (scrut->getclass() == CEXPR)
+      {
+        scrut = static_cast<CExpr*>(scrut)->whr();
+      }
       vector<Expr *> args;
       Expr *hd = scrut->collect_args(args);
       Expr **cases = &e->kids[1];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(lfsc_test_file_list
   unused_pi_param_rational_in_body.plf
   use-bool.plf
   use-use-bool.plf
+  whr-match.plf
 )
 
 set(test_script ${CMAKE_CURRENT_LIST_DIR}/run_test.py)

--- a/tests/tests/whr-match.plf
+++ b/tests/tests/whr-match.plf
@@ -1,0 +1,18 @@
+(declare sort type)
+(declare term type)
+(declare apply (! t1 term (! t2 term term)))
+(declare f_real term)
+(declare x term)
+(declare bool type)
+(declare true bool)
+(declare false bool)
+
+(define f (: (! t term term) (\ t (apply f_real t))))
+
+(program check_is_app ((t term)) bool
+         (match t
+                ((apply t1 t2) true)
+                (default false)))
+
+(declare is_app (! t term (! b bool (! sc (^ (check_is_app t) b) bool))))
+(check (is_app (f x) true))


### PR DESCRIPTION
For pattern-matching in a functional language, you must reduce the
scrutinee before matching. Otherwise you don't know what value you're
matching the head against.

Even in haskell, a lazy language, they have to do WHR to the scrutinee
(this is the source of *all* eagerness in haskell's core).

Added a test to illustrate the problem.

Thanks Yoni & Andrew for finding the issue!