### PR TITLE
Error on top-level rebind. Tests for errors.

### DIFF
--- a/src/check.cpp
+++ b/src/check.cpp
@@ -968,6 +968,13 @@ void check_file(const char *_filename, args a, sccwriter *scw, libwriter *lw)
   fs.close();
 }
 
+void rebind_error(const std::string& id)
+{
+  stringstream o;
+  o << "The top-level identifier \"" << id << "\" was already bound";
+  report_error(o.str());
+}
+
 void check_file(std::istream& in,
                 const std::string& _filename,
                 args a,
@@ -1006,8 +1013,10 @@ void check_file(std::istream& in,
           s->val = t;
           pair<Expr*, Expr*> prev =
               symbols->insert(id.c_str(), pair<Expr*, Expr*>(s, ttp));
-          if (prev.first) prev.first->dec();
-          if (prev.second) prev.second->dec();
+          if (prev.first || prev.second)
+          {
+            rebind_error(id);
+          }
           break;
         }
         case Token::Declare:
@@ -1030,8 +1039,10 @@ void check_file(std::istream& in,
           pair<Expr*, Expr*> prev =
               symbols->insert(id.c_str(), pair<Expr*, Expr*>(s, t));
           if (lw) lw->add_symbol(s, t);
-          if (prev.first) prev.first->dec();
-          if (prev.second) prev.second->dec();
+          if (prev.first || prev.second)
+          {
+            rebind_error(id);
+          }
           break;
         }
         case Token::Check:
@@ -1088,8 +1099,10 @@ void check_file(std::istream& in,
           SymSExpr* s = new SymSExpr(id);
           pair<Expr*, Expr*> prev =
               symbols->insert(id.c_str(), pair<Expr*, Expr*>(s, ttp));
-          if (prev.first) prev.first->dec();
-          if (prev.second) prev.second->dec();
+          if (prev.first || prev.second)
+          {
+            rebind_error(id);
+          }
           break;
         }
         case Token::Run:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,9 @@ set(lfsc_test_file_list
   mpz_to_mpq.plf
   mpz_to_mpq_checks.plf
   num.plf
+  redecl.plf
+  redefn.plf
+  reopaque.plf
   sage-app2-bench_201.plf
   sat.plf
   semicolon_after_id.plf

--- a/tests/tests/redecl.plf
+++ b/tests/tests/redecl.plf
@@ -1,0 +1,3 @@
+; Error Line: 3
+(declare a type)
+(declare a mpz)

--- a/tests/tests/redefn.plf
+++ b/tests/tests/redefn.plf
@@ -1,0 +1,3 @@
+; Error Line: 3
+(declare a mpz)
+(define a 1)

--- a/tests/tests/reopaque.plf
+++ b/tests/tests/reopaque.plf
@@ -1,0 +1,3 @@
+; Error Line: 3
+(declare a mpz)
+(opaque a 1)

--- a/tests/tests/th_bv.plf
+++ b/tests/tests/th_bv.plf
@@ -87,7 +87,6 @@
 
 (declare bvand bvop2)
 (declare bvor bvop2)
-(declare bvor bvop2)
 (declare bvxor bvop2)
 (declare bvnand bvop2)
 (declare bvnor bvop2)
@@ -103,7 +102,6 @@
 (declare bvshl bvop2)
 (declare bvlshr bvop2)
 (declare bvashr bvop2)
-(declare concat bvop2)
 
 ; bit vector unary operators
 (define bvop1


### PR DESCRIPTION
We now regard top-level name rebinding as an error.

Test machinery for verifying errors are thrown, and specific tests for
errors on 3 kinds of rebinds.

Credits to Yoni for bringing this issue up.