### PR TITLE
Stricter FLEX checking & note about CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,14 @@ else()
 endif()
 
 find_package(FLEX REQUIRED)
+if (FLEX_FOUND AND NOT ${FLEX_INCLUDE_DIRS} STREQUAL "FLEX_INCLUDE_DIR-NOTFOUND")
+    message(STATUS "Flex include directories: ${FLEX_INCLUDE_DIRS}")
+    message(STATUS "Flex executable: ${FLEX_EXECUTABLE}")
+    message(STATUS "Flex version: ${FLEX_VERSION}")
+else()
+  message(FATAL_ERROR "Could not find flex!")
+  exit()
+endif()
 
 enable_testing()
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Authors: Andy Reynolds and Aaron Stump
 
 ## Building LFSC checker
 
-You need cmake (>= version 2.8.9) to build LFSC Checker.
+You need cmake (>= version 2.8.9), gmp, and flex to build LFSC Checker.
 
 To build a regular build, issue:
 
@@ -136,3 +136,9 @@ svn co https://svn.divms.uiowa.edu/repos/clc/clsat/trunk clsat
 ```
 
 should produce proofs compatible with the current version of sat.plf.
+
+## Build Debugging
+
+Sometime CMake may have a difficult time finding FLEX on your system. It can
+be helpful to set the `CMAKE_INCLUDE_PATH` path to the location of your flex
+installation.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set(srcfiles
 
 flex_target(Lexer lexer.flex  ${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp)
 add_library (objlib OBJECT ${srcfiles} ${FLEX_Lexer_OUTPUTS})
+include_directories (${FLEX_INCLUDE_DIRS})
 set_property (TARGET objlib PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 add_executable (lfscc $<TARGET_OBJECTS:objlib> main.cpp)
@@ -32,7 +33,7 @@ install (TARGETS lfscc
 add_library (liblfscc STATIC $<TARGET_OBJECTS:objlib>)
 set_target_properties (liblfscc PROPERTIES
   OUTPUT_NAME lfscc
-  PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/lfscc.h"  
+  PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/lfscc.h"
 )
 install (TARGETS liblfscc
   ARCHIVE DESTINATION "${CMAKE_INSTALL_PREFIX}/lib"


### PR DESCRIPTION
Some weird behavior in FindFLEX.cmake causes it to *not* fail in some situations in which the CMake installation is not fully found.

This PR adds some defensive programming.

closes #47 