### PR TITLE
LFSC Syntax Extensions

### DIFF
--- a/src/check.cpp
+++ b/src/check.cpp
@@ -1517,7 +1517,8 @@ void check_file(std::istream& in,
                                 Token::Check,
                                 Token::Program,
                                 Token::DeclareRule,
-                                Token::DeclareType})
+                                Token::DeclareType,
+                                Token::DefineConst})
           {
             msg << "\n\t" << t;
           }

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -188,17 +188,18 @@ start_check:
         case Token::Arrow:
         {  // the arrow case
           DeclList decls = check_decl_list(create);
-          Expr * ret_kind;
-          Expr * ret = check(create, nullptr, &ret_kind);
+          Expr* ret_kind;
+          Expr* ret = check(create, nullptr, &ret_kind);
           for (const auto binding : decls.old_bindings)
           {
-            symbols->insert(get<0>(binding).c_str(), {get<1>(binding), get<2>(binding)});
+            symbols->insert(get<0>(binding).c_str(),
+                            {get<1>(binding), get<2>(binding)});
           }
           eat_rparen();
           auto p = build_validate_pi(move(decls.decls), ret, ret_kind, create);
           if (expected)
           {
-            //Checked by build-validate pi
+            // Checked by build-validate pi
             p.second->dec();
           }
           else
@@ -974,7 +975,7 @@ start_check:
   return 0;
 }
 
-std::pair<std::string, Expr *> check_decl_list_item()
+std::pair<std::string, Expr*> check_decl_list_item()
 {
   Token::Token t = next_token();
   if (t == Token::Open)
@@ -983,38 +984,38 @@ std::pair<std::string, Expr *> check_decl_list_item()
     if (t2 == Token::Colon)
     {
       string id(prefix_id());
-      Expr * ty = check(true, statType);
+      Expr* ty = check(true, statType);
       eat_token(Token::Close);
-      return { id, ty };
+      return {id, ty};
     }
     else
     {
       reinsert_token(t2);
       reinsert_token(t);
-      Expr * dummy;
-      Expr * ty = check(true, nullptr, &dummy);
+      Expr* dummy;
+      Expr* ty = check(true, nullptr, &dummy);
       dummy->dec();
-      return { "", ty };
+      return {"", ty};
     }
   }
   else
   {
     reinsert_token(t);
-    Expr * ty = check(true, statType);
-    return { "", ty };
+    Expr* ty = check(true, statType);
+    return {"", ty};
   }
 }
 
 DeclList check_decl_list(const bool create)
 {
-  std::vector<std::tuple<std::string,Expr *, Expr *>> old_bindings;
-  std::vector<std::pair<Expr *, Expr *>> decls;
+  std::vector<std::tuple<std::string, Expr*, Expr*>> old_bindings;
+  std::vector<std::pair<Expr*, Expr*>> decls;
   eat_token(Token::Open);
   Token::Token t = next_token();
   while (t != Token::Close)
   {
     reinsert_token(t);
-    std::pair<std::string, Expr *> p = check_decl_list_item();
+    std::pair<std::string, Expr*> p = check_decl_list_item();
     Expr* sym;
     if (p.first.size())
     {
@@ -1023,8 +1024,8 @@ DeclList check_decl_list(const bool create)
 #else
       sym = new SymExpr(p.first);
 #endif
-      auto o = symbols->insert(p.first.c_str(), { sym, p.second });
-      old_bindings.push_back({ p.first, o.first, o.second });
+      auto o = symbols->insert(p.first.c_str(), {sym, p.second});
+      old_bindings.push_back({p.first, o.first, o.second});
     }
     else
     {
@@ -1041,7 +1042,7 @@ DeclList check_decl_list(const bool create)
     }
     t = next_token();
   }
-  return { decls, old_bindings };
+  return {decls, old_bindings};
 }
 
 std::pair<Expr*, Expr*> build_validate_pi(
@@ -1069,10 +1070,9 @@ std::pair<Expr*, Expr*> build_validate_pi(
   return {nullptr, nullptr};
 }
 
-std::pair<Expr*, Expr*> build_macro(
-    std::vector<std::pair<Expr*, Expr*>>&& args,
-    Expr* ret,
-    Expr* ret_ty)
+std::pair<Expr*, Expr*> build_macro(std::vector<std::pair<Expr*, Expr*>>&& args,
+                                    Expr* ret,
+                                    Expr* ret_ty)
 {
   for (size_t i = args.size() - 1; i < args.size(); --i)
   {
@@ -1193,13 +1193,15 @@ void check_file(std::istream& in,
         {
           string id(prefix_id());
           DeclList decls = check_decl_list(true);
-          Expr * ret_kind;
-          Expr * ret = check(true, nullptr, &ret_kind);
+          Expr* ret_kind;
+          Expr* ret = check(true, nullptr, &ret_kind);
           for (const auto binding : decls.old_bindings)
           {
-            symbols->insert(get<0>(binding).c_str(), {get<1>(binding), get<2>(binding)});
+            symbols->insert(get<0>(binding).c_str(),
+                            {get<1>(binding), get<2>(binding)});
           }
-          pair<Expr *, Expr *> p = build_validate_pi(move(decls.decls), ret, ret_kind, true);
+          pair<Expr*, Expr*> p =
+              build_validate_pi(move(decls.decls), ret, ret_kind, true);
           p.second->dec();
           SymSExpr* s = new SymSExpr(id);
           pair<Expr*, Expr*> prev =
@@ -1217,9 +1219,11 @@ void check_file(std::istream& in,
           DeclList decls = check_decl_list(true);
           for (const auto binding : decls.old_bindings)
           {
-            symbols->insert(get<0>(binding).c_str(), {get<1>(binding), get<2>(binding)});
+            symbols->insert(get<0>(binding).c_str(),
+                            {get<1>(binding), get<2>(binding)});
           }
-          pair<Expr *, Expr *> p = build_validate_pi(move(decls.decls), statType, statKind, true);
+          pair<Expr*, Expr*> p =
+              build_validate_pi(move(decls.decls), statType, statKind, true);
           p.second->dec();
           SymSExpr* s = new SymSExpr(id);
           pair<Expr*, Expr*> prev =
@@ -1235,14 +1239,17 @@ void check_file(std::istream& in,
         {
           string id(prefix_id());
           DeclList decls = check_decl_list(true);
-          Expr * ret_ty;
-          Expr * ret = check(true, nullptr, &ret_ty);
-          pair<Expr *, Expr *> macro = build_macro(move(decls.decls), ret, ret_ty);
+          Expr* ret_ty;
+          Expr* ret = check(true, nullptr, &ret_ty);
+          pair<Expr*, Expr*> macro =
+              build_macro(move(decls.decls), ret, ret_ty);
           for (const auto binding : decls.old_bindings)
           {
-            symbols->insert(get<0>(binding).c_str(), {get<1>(binding), get<2>(binding)});
+            symbols->insert(get<0>(binding).c_str(),
+                            {get<1>(binding), get<2>(binding)});
           }
-          pair<Expr *, Expr *> prev = symbols->insert(id.c_str(), {macro.first, macro.second});
+          pair<Expr*, Expr*> prev =
+              symbols->insert(id.c_str(), {macro.first, macro.second});
           if (prev.first || prev.second)
           {
             rebind_error(id);
@@ -1278,7 +1285,7 @@ void check_file(std::istream& in,
             ascHoles.clear();
             computed->dec();
           }
-          else // CheckAssuming
+          else  // CheckAssuming
           {
             DeclList decls = check_decl_list(false);
             Expr* ex_type = check(true, statType, nullptr);

--- a/src/check.h
+++ b/src/check.h
@@ -50,12 +50,13 @@ void check_file(std::istream& in,
                 sccwriter* scw = NULL,
                 libwriter* lw = NULL);
 
-struct DeclList {
+struct DeclList
+{
   // The declarations: (symbol, type) pairs.
-  std::vector<std::pair<Expr *, Expr *>> decls;
+  std::vector<std::pair<Expr*, Expr*>> decls;
   // Old bindings to restore:
   // (name, old value, old type).
-  std::vector<std::tuple<std::string, Expr *, Expr *>> old_bindings;
+  std::vector<std::tuple<std::string, Expr*, Expr*>> old_bindings;
 };
 
 // Checks for a declaration list item.
@@ -66,7 +67,7 @@ struct DeclList {
 // Returns a pair:
 //   the declared symbol         (name "_" if none)
 //   the type of the declaration
-std::pair<std::string, Expr *> check_decl_list_item();
+std::pair<std::string, Expr*> check_decl_list_item();
 
 // Checks a list of declarations
 // e.g.
@@ -79,11 +80,10 @@ std::pair<Expr*, Expr*> build_validate_pi(
     Expr* ret,
     Expr* ret_kind,
     bool create);
-std::pair<Expr*, Expr*> build_macro(
-    std::vector<std::pair<Expr*, Expr*>>&& args,
-    Expr* ret,
-    Expr* ret_ty,
-    bool create);
+std::pair<Expr*, Expr*> build_macro(std::vector<std::pair<Expr*, Expr*>>&& args,
+                                    Expr* ret,
+                                    Expr* ret_ty,
+                                    bool create);
 
 void cleanup();
 

--- a/src/check.h
+++ b/src/check.h
@@ -56,30 +56,64 @@ struct DeclList
   std::vector<std::pair<Expr*, Expr*>> decls;
   // Old bindings to restore:
   // (name, old value, old type).
+  // Necessary because, for each (symbol, type) pair in the `decls`, we bind
+  // `symbol` to `type` in the enviroment, possibly overwriting the prior
+  // binding for `symbol`. This member contains the information needed to
+  // restore the binding.
   std::vector<std::tuple<std::string, Expr*, Expr*>> old_bindings;
 };
 
 // Checks for a declaration list item.
 // Such items have two forms:
-//   (id NAME TYPE) -> (VarExpr(NAME), Expr(TYPE))
+//   (:  NAME TYPE) -> (VarExpr(NAME), Expr(TYPE))
 //   TYPE           -> (nullpty      , Expr(TYPE))
 //
 // Returns a pair:
-//   the declared symbol         (name "_" if none)
-//   the type of the declaration
+//   the name of the declared symbol ("" if no name)
+//   the type of the declaration     (TYPE in the above)
 std::pair<std::string, Expr*> check_decl_list_item();
 
 // Checks a list of declarations
 // e.g.
-//   ((id a bool) bool (id p (holds a)))
-// See DeclList structure
+//   ((: a bool) bool (: p (holds a)))
+// Returns a list of (symbol, type) bindings ("_" is the symbol for
+// declarations which are anonymous), binding those symbols in the enviroment
+// as it does.  Also returns a list of old bindings.
+//
+// See DeclList structure documentation for the details of the return value.
+//
+// If create is not set, then we return an empty list of declarations.
+// The old bindings are still returned.
 DeclList check_decl_list(bool create);
 
+// Builds an validates a nested PI expression.
+//
+// E.g., from (a bool) (b bool) ..., it builds (! a bool (! b bool ...))
+//
+// Parameters:
+// * `args`: a (symbol, type) list. Each member corresponds to one PI in the
+// nest.
+// * `ret`: the body of the innermost PI
+// * `ret_kind`: the type of the innermost PI
+// * `create`: whether to acutally build the body of the constructed PI
+//             (the type of the PI is always constructed)
+// Returns:
+// * The body of the constructed PI
+// * The type of the constructed PI (which is just the ret_kind, it turns out)
+//
+// Note:
+// Checks that the PI's return kind is TYPE or KIND. Otherwise, throws an error.
 std::pair<Expr*, Expr*> build_validate_pi(
     std::vector<std::pair<Expr*, Expr*>>&& args,
     Expr* ret,
     Expr* ret_kind,
     bool create);
+
+// Builds and validates a nested macro (LAM) expression.
+// Very similar to the above, except:
+// * Always constructs the body of the nested LAM.
+// * Checks that each layer of the type of the nested LAM (which is a nested
+//   PI) is not dependent.
 std::pair<Expr*, Expr*> build_macro(std::vector<std::pair<Expr*, Expr*>>&& args,
                                     Expr* ret,
                                     Expr* ret_ty,

--- a/src/check.h
+++ b/src/check.h
@@ -50,6 +50,36 @@ void check_file(std::istream& in,
                 sccwriter* scw = NULL,
                 libwriter* lw = NULL);
 
+struct DeclList {
+  // The declarations: (symbol, type) pairs.
+  std::vector<std::pair<Expr *, Expr *>> decls;
+  // Old bindings to restore:
+  // (name, old value, old type).
+  std::vector<std::tuple<std::string, Expr *, Expr *>> old_bindings;
+};
+
+// Checks for a declaration list item.
+// Such items have two forms:
+//   (id NAME TYPE) -> (VarExpr(NAME), Expr(TYPE))
+//   TYPE           -> (nullpty      , Expr(TYPE))
+//
+// Returns a pair:
+//   the declared symbol         (name "_" if none)
+//   the type of the declaration
+std::pair<std::string, Expr *> check_decl_list_item();
+
+// Checks a list of declarations
+// e.g.
+//   ((id a bool) bool (id p (holds a)))
+// See DeclList structure
+DeclList check_decl_list(bool create);
+
+std::pair<Expr*, Expr*> build_validate_pi(
+    std::vector<std::pair<Expr*, Expr*>>&& args,
+    Expr* ret,
+    Expr* ret_kind,
+    bool create);
+
 void cleanup();
 
 

--- a/src/check.h
+++ b/src/check.h
@@ -79,6 +79,11 @@ std::pair<Expr*, Expr*> build_validate_pi(
     Expr* ret,
     Expr* ret_kind,
     bool create);
+std::pair<Expr*, Expr*> build_macro(
+    std::vector<std::pair<Expr*, Expr*>>&& args,
+    Expr* ret,
+    Expr* ret_ty,
+    bool create);
 
 void cleanup();
 

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -134,7 +134,7 @@ Expr *read_code()
 
           return new CExpr(FAIL, c);
         }
-        case Token::Let:
+        case Token::At:
         {
           string id(prefix_id());
           SymSExpr* var = new SymSExpr(id);

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -404,7 +404,7 @@ bool Expr::defeq(Expr *e)
   /* we handle a few special cases up front, where this Expr might
      equal e, even though they have different opclass (i.e., different
      structure). */
-
+  // cerr << "defeq " << *e << "\n      " << *this << endl;
   if (this == e) return true;
   int op1 = getop();
   int op2 = e->getop();
@@ -854,8 +854,8 @@ void Expr::print(ostream &os) const
             else
             {
 #ifdef DEBUG_SYMS
-              os << e->s;
-              os << "[SYM ";
+              os << e;
+              os << "[value ";
 #endif
               e->val->print(os);
 #ifdef DEBUG_SYMS
@@ -865,6 +865,9 @@ void Expr::print(ostream &os) const
           }
           else
             os << e->s;
+#ifdef DEBUG_SYMS
+            os << "[" << e << "]";
+#endif
           break;
         }
         case HOLE_EXPR:

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -404,7 +404,7 @@ bool Expr::defeq(Expr *e)
   /* we handle a few special cases up front, where this Expr might
      equal e, even though they have different opclass (i.e., different
      structure). */
-  // cerr << "defeq " << *e << "\n      " << *this << endl;
+
   if (this == e) return true;
   int op1 = getop();
   int op2 = e->getop();
@@ -854,8 +854,8 @@ void Expr::print(ostream &os) const
             else
             {
 #ifdef DEBUG_SYMS
-              os << e;
-              os << "[value ";
+              os << e->s;
+              os << "[SYM ";
 #endif
               e->val->print(os);
 #ifdef DEBUG_SYMS
@@ -865,9 +865,6 @@ void Expr::print(ostream &os) const
           }
           else
             os << e->s;
-#ifdef DEBUG_SYMS
-          os << "[" << e << "]";
-#endif
           break;
         }
         case HOLE_EXPR:

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -866,7 +866,7 @@ void Expr::print(ostream &os) const
           else
             os << e->s;
 #ifdef DEBUG_SYMS
-            os << "[" << e << "]";
+          os << "[" << e << "]";
 #endif
           break;
         }

--- a/src/expr.h
+++ b/src/expr.h
@@ -12,6 +12,7 @@
 #include "gmp.h"
 
 #define DEBUG_SYM_NAMES
+// Uncomment for verbose printing of symbols
 //#define DEBUG_SYMS
 
 // Expr class

--- a/src/lexer.flex
+++ b/src/lexer.flex
@@ -73,7 +73,7 @@ comment     ;[^\n]*\n
 "declare-rule"  return Token::DeclareRule;
 "declare-type"  return Token::DeclareType;
 "define-const"  return Token::DefineConst;
-"forall"        return Token::Forall;
+"pi"            return Token::Forall;
 "->"            return Token::Arrow;
 "lam"           return Token::Lam;
 "check-assuming" return Token::CheckAssuming;

--- a/src/lexer.flex
+++ b/src/lexer.flex
@@ -72,12 +72,11 @@ comment     ;[^\n]*\n
 "provided"      return Token::Provided;
 "declare-rule"  return Token::DeclareRule;
 "declare-type"  return Token::DeclareType;
+"define-const"  return Token::DefineConst;
 "Forall"        return Token::Forall;
 "->"            return Token::Arrow;
 "lam"           return Token::Lam;
-"id"            return Token::Id;
-"proved-by"     return Token::ProvedBy;
-"assuming"      return Token::Assuming;
+"check-assuming" return Token::CheckAssuming;
 
 {markvar}       return Token::MarkVar;
 {ifmarked}      return Token::IfMarked;
@@ -163,10 +162,6 @@ Token::Token next_token()
       }
       case Token::Let: {
         t = Token::At;
-        break;
-      }
-      case Token::ProvedBy: {
-        t = Token::Colon;
         break;
       }
       default: break;

--- a/src/lexer.flex
+++ b/src/lexer.flex
@@ -113,7 +113,6 @@ Span s_span = {1,1,1,1};
 
 void reinsert_token(Token::Token t)
 {
-  //std::cerr << "Reinsert: " << t << std::endl;
   if (s_peeked[0] == Token::TokenErr)
   {
     s_peeked[0] = t;
@@ -166,7 +165,6 @@ Token::Token next_token()
       }
       default: break;
     }
-    //std::cerr << "Token: " << t << " " << token_str() << std::endl;
   return t;
 }
 

--- a/src/lexer.flex
+++ b/src/lexer.flex
@@ -73,7 +73,7 @@ comment     ;[^\n]*\n
 "declare-rule"  return Token::DeclareRule;
 "declare-type"  return Token::DeclareType;
 "define-const"  return Token::DefineConst;
-"Forall"        return Token::Forall;
+"forall"        return Token::Forall;
 "->"            return Token::Arrow;
 "lam"           return Token::Lam;
 "check-assuming" return Token::CheckAssuming;

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -29,13 +29,17 @@ std::ostream& operator<<(std::ostream& o, const Span& l);
 extern FlexLexer* s_lexer;
 // Name of current file
 extern std::string s_filename;
-extern Token::Token s_peeked;
+// buffer. 0 it first, then 1.
+extern Token::Token s_peeked[2];
 extern Span s_span;
 
+// Public interface
 Token::Token next_token();
+void reinsert_token(Token::Token t);
+const char * token_str();
+
 void eat_token(Token::Token t);
 std::string prefix_id();
-void reinsert_token(Token::Token t);
 void report_error(const std::string&);
 void unexpected_token_error(Token::Token t, const std::string& info);
 void init_s_span();

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -25,26 +25,51 @@ struct Span {
 std::ostream& operator<<(std::ostream& o, const Location& l);
 std::ostream& operator<<(std::ostream& o, const Span& l);
 
+// Lexer explanation.
+//
+// This a lookahead-two lexer, backed by a length-two buffer.
+//
+// View it as a stack of tokens. The topmost is first.
+//
+// It is implemented with functions for pulling tokens out of the lexer,
+// getting information about the token just pulled, and pushing a token back
+// into the conceptual stream/concrete buffer.
+
+// Private components
 // Currrent lexer
 extern FlexLexer* s_lexer;
 // Name of current file
 extern std::string s_filename;
-// buffer. 0 it first, then 1.
+// The buffer. 0 is first, then 1.
 extern Token::Token s_peeked[2];
-extern Span s_span;
-
-// Public interface
-Token::Token next_token();
-void reinsert_token(Token::Token t);
-const char* token_str();
-
-void eat_token(Token::Token t);
-std::string prefix_id();
-void report_error(const std::string&);
-void unexpected_token_error(Token::Token t, const std::string& info);
+// Used to initialize s_span.
 void init_s_span();
+// Sets the spans start to its current end.
 void bump_span();
+// Add columns or lines to the end location of the span.
 void add_columns(uint32_t columns);
 void add_lines(uint32_t lines);
+
+// Public interface
+
+// Core functions
+// Advance to the next token (pop from stack)
+Token::Token next_token();
+// Add a token back into the stream (push to stack)
+void reinsert_token(Token::Token t);
+// String corresponding to the last token (old top of stack)
+const char* token_str();
+// Span of last token pulled from underlying lexer (old top of stack)
+extern Span s_span;
+// Used to report errors, with the current source location attached.
+void report_error(const std::string&);
+
+// Derived functions
+// Expect a token `t` as the next one. Error o.w.
+void eat_token(Token::Token t);
+// Interpret the next token as an identifier (even if it isn't) and return its string
+std::string prefix_id();
+// Error. Got `t`, expected `info`.
+void unexpected_token_error(Token::Token t, const std::string& info);
 
 #endif  // SC2_LEXER_H

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -36,7 +36,7 @@ extern Span s_span;
 // Public interface
 Token::Token next_token();
 void reinsert_token(Token::Token t);
-const char * token_str();
+const char* token_str();
 
 void eat_token(Token::Token t);
 std::string prefix_id();

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -49,14 +49,13 @@ std::ostream& operator<<(std::ostream& o, Token t)
     case Ident: return o << "Ident";
     case TokenErr: return o << "TokenErr";
     case Provided: return o << "Provided";
-    case Id: return o << "Id";
     case DeclareRule: return o << "DeclareRule";
     case DeclareType: return o << "DeclareType";
+    case DefineConst: return o << "DefineConst";
     case Forall: return o << "Forall";
     case Arrow: return o << "Arrow";
     case Lam: return o << "Lam";
-    case ProvedBy: return o << "ProvedBy";
-    case Assuming: return o << "Assuming";
+    case CheckAssuming: return o << "CheckAssuming";
     default: return o << "Unknown Token: " << unsigned(t);
   }
 }

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -48,6 +48,15 @@ std::ostream& operator<<(std::ostream& o, Token t)
     case Rational: return o << "Rational";
     case Ident: return o << "Ident";
     case TokenErr: return o << "TokenErr";
+    case Provided: return o << "Provided";
+    case Id: return o << "Id";
+    case DeclareRule: return o << "DeclareRule";
+    case DeclareType: return o << "DeclareType";
+    case Forall: return o << "Forall";
+    case Arrow: return o << "Arrow";
+    case Lam: return o << "Lam";
+    case ProvedBy: return o << "ProvedBy";
+    case Assuming: return o << "Assuming";
     default: return o << "Unknown Token: " << unsigned(t);
   }
 }

--- a/src/token.h
+++ b/src/token.h
@@ -61,13 +61,12 @@ enum Token : int
   Provided,
   Forall,
   Lam,
-  ProvedBy,
   // Some are checked:
-  Id,
   DeclareRule,
+  DefineConst,
   DeclareType,
   Arrow,
-  Assuming,
+  CheckAssuming,
 
   TokenErr,
 

--- a/src/token.h
+++ b/src/token.h
@@ -56,7 +56,21 @@ enum Token : int
 
   Ident,
 
+  // Extension tokens.
+  // Some are desugared away:
+  Provided,
+  Forall,
+  Lam,
+  ProvedBy,
+  // Some are checked:
+  Id,
+  DeclareRule,
+  DeclareType,
+  Arrow,
+  Assuming,
+
   TokenErr,
+
 };
 
 std::ostream& operator<<(std::ostream& o, Token t);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,15 @@ set(lfsc_test_file_list
   use-bool.plf
   use-use-bool.plf
   whr-match.plf
+  sugar_arrow.plf
+  sugar_assuming.plf
+  sugar_declare_rule.plf
+  sugar_declare_type.plf
+  sugar_forall.plf
+  sugar_lam.plf
+  sugar_let.plf
+  sugar_proved_by.plf
+  sugar_provided.plf
 )
 
 set(test_script ${CMAKE_CURRENT_LIST_DIR}/run_test.py)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ set(lfsc_test_file_list
   sugar_forall.plf
   sugar_lam.plf
   sugar_let.plf
-  sugar_proved_by.plf
+  sugar_define_const.plf
   sugar_provided.plf
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ set(lfsc_test_file_list
   sugar_let.plf
   sugar_define_const.plf
   sugar_provided.plf
+  sugar_skolem.plf
 )
 
 set(test_script ${CMAKE_CURRENT_LIST_DIR}/run_test.py)

--- a/tests/tests/skolem1.plf
+++ b/tests/tests/skolem1.plf
@@ -12,7 +12,7 @@
 (define = (# t1 term (# t2 term (apply (apply f_= t1) t2))))
 (declare var (! v mpz (! s sort term)))
 (declare bvar (! v mpz (! s sort term)))
-(declare forall (! v mpz (! s sort term)))
+(declare forall_ (! v mpz (! s sort term)))
 (declare witness (! v mpz (! s sort term)))
 (declare map_to_witness (! k term (! w term type)))
 (declare Ok type)
@@ -40,7 +40,7 @@
                      (! v mpz
                      (! s sort
 		     (! goal term
-                     (! p (holds (not (apply (forall v s) body)))
+                     (! p (holds (not (apply (forall_ v s) body)))
 		     (! u (! v' mpz
 		          (! r (map_to_witness (var v' s) (apply (witness v s)
 		               (not body)))
@@ -52,7 +52,7 @@
                      (! s sort
                      (! bodyi term
 		     (! k term
-                     (! p (holds (not (apply (forall v s) body)))
+                     (! p (holds (not (apply (forall_ v s) body)))
 		     (! u (map_to_witness k (apply (witness v s) (not body)))
                      (! r (^ (substitute body v k) bodyi)
 		     (holds (not bodyi)))))))))))
@@ -63,7 +63,7 @@
 
 (check
 (% p1 (holds (not (= a b)))
-(% p2 (holds (not (apply (forall 7 U) (not (and (= a (bvar 7 U)) (= (bvar 7 U) b))))))
+(% p2 (holds (not (apply (forall_ 7 U) (not (and (= a (bvar 7 U)) (= (bvar 7 U) b))))))
 (: (holds false)
   (mk_skolemize _ _ _ _ p2
     (\ v' (\ r

--- a/tests/tests/skolem2.plf
+++ b/tests/tests/skolem2.plf
@@ -12,7 +12,7 @@
 (define = (# t1 term (# t2 term (apply (apply f_= t1) t2))))
 (declare var (! v mpz (! s sort term)))
 (declare bvar (! v mpz (! s sort term)))
-(declare forall (! v mpz (! s sort term)))
+(declare forall_ (! v mpz (! s sort term)))
 (declare witness (! v mpz (! s sort term)))
 (declare map_to_witness (! k term (! w term type)))
 (declare Ok type)
@@ -40,7 +40,7 @@
                      (! v mpz
                      (! s sort
 		     (! goal term
-                     (! p (holds (not (apply (forall v s) body)))
+                     (! p (holds (not (apply (forall_ v s) body)))
 		     (! u (! v' mpz
 		          (! r (map_to_witness (var v' s) (apply (witness v s)
 		               (not body)))
@@ -52,7 +52,7 @@
                      (! s sort
                      (! bodyi term
 		     (! k term
-                     (! p (holds (not (apply (forall v s) body)))
+                     (! p (holds (not (apply (forall_ v s) body)))
 		     (! u (map_to_witness k (apply (witness v s) (not body)))
                      (! r (^ (substitute body v k) bodyi)
 		     (holds (not bodyi)))))))))))
@@ -63,7 +63,7 @@
 
 (check
 (% p1 (holds (not (= a b)))
-(% p2 (holds (not (apply (forall 7 U) (not (and (= a (bvar 7 U)) (= (bvar 7 U) b))))))
+(% p2 (holds (not (apply (forall_ 7 U) (not (and (= a (bvar 7 U)) (= (bvar 7 U) b))))))
 (: (holds false)
   (mk_skolemize _ _ _ _ p2 (\ v' (\ r
       (@ sko (skolemize _ _ _ _ _ p2 r)

--- a/tests/tests/sugar_arrow.plf
+++ b/tests/tests/sugar_arrow.plf
@@ -1,4 +1,4 @@
-(declare bool type)
+(declare-type bool ())
 (declare tt bool)
 (declare ff bool)
 
@@ -7,8 +7,8 @@
 ; (declare bad (-> () bool))
 
 (declare pf_and
-         (-> ((id a bool)
-              (id b bool)
+         (-> ((: a bool)
+              (: b bool)
               (holds a)
               (holds b))
              (holds (and a b))))

--- a/tests/tests/sugar_arrow.plf
+++ b/tests/tests/sugar_arrow.plf
@@ -1,0 +1,30 @@
+(declare bool type)
+(declare tt bool)
+(declare ff bool)
+
+(declare holds (-> (bool) type))
+(declare and (-> (bool bool) bool))
+; (declare bad (-> () bool))
+
+(declare pf_and
+         (-> ((id a bool)
+              (id b bool)
+              (holds a)
+              (holds b))
+             (holds (and a b))))
+
+(check
+  (% a bool
+  (% b bool
+  (% pf_a (holds a)
+  (% pf_b (holds b)
+  (: (holds (and a b))
+     (pf_and a b pf_a pf_b)))))))
+(check
+  (% a bool
+  (% b bool
+  (% pf_a (holds a)
+  (% pf_b (holds b)
+  (: (holds (and a b))
+     (pf_and _ _ pf_a pf_b)))))))
+

--- a/tests/tests/sugar_assuming.plf
+++ b/tests/tests/sugar_assuming.plf
@@ -4,6 +4,7 @@
 
 (declare holds (! b bool type))
 
-(check (assuming ((id b bool)
-                  (id b_pf (holds b)))
-                                  (: (holds b) b_pf)))
+(check-assuming ((: b bool)
+                 (: b_pf (holds b)))
+                (holds b)
+                b_pf)

--- a/tests/tests/sugar_assuming.plf
+++ b/tests/tests/sugar_assuming.plf
@@ -1,0 +1,9 @@
+(declare bool type)
+(declare tt bool)
+(declare ff bool)
+
+(declare holds (! b bool type))
+
+(check (assuming ((id b bool)
+                  (id b_pf (holds b)))
+                                  (: (holds b) b_pf)))

--- a/tests/tests/sugar_declare_rule.plf
+++ b/tests/tests/sugar_declare_rule.plf
@@ -6,8 +6,8 @@
 (declare and (! a bool (! b bool bool)))
 
 (declare-rule pf_and
-              ((id a bool)
-               (id b bool)
+              ((: a bool)
+               (: b bool)
                (holds a)
                (holds b))
               (holds (and a b)))

--- a/tests/tests/sugar_declare_rule.plf
+++ b/tests/tests/sugar_declare_rule.plf
@@ -1,0 +1,28 @@
+(declare bool type)
+(declare tt bool)
+(declare ff bool)
+
+(declare holds (! b bool type))
+(declare and (! a bool (! b bool bool)))
+
+(declare-rule pf_and
+              ((id a bool)
+               (id b bool)
+               (holds a)
+               (holds b))
+              (holds (and a b)))
+
+(check
+  (% a bool
+  (% b bool
+  (% pf_a (holds a)
+  (% pf_b (holds b)
+  (: (holds (and a b))
+     (pf_and a b pf_a pf_b)))))))
+(check
+  (% a bool
+  (% b bool
+  (% pf_a (holds a)
+  (% pf_b (holds b)
+  (: (holds (and a b))
+     (pf_and _ _ pf_a pf_b)))))))

--- a/tests/tests/sugar_declare_type.plf
+++ b/tests/tests/sugar_declare_type.plf
@@ -1,0 +1,28 @@
+(declare-type bool ())
+(declare tt bool)
+(declare ff bool)
+
+(declare-type holds (bool))
+(declare and (! a bool (! b bool bool)))
+
+(declare pf_and
+         (! a bool
+         (! b bool
+         (! a_pf (holds a)
+         (! b_pf (holds b)
+            (holds (and a b)))))))
+
+(check
+  (% a bool
+  (% b bool
+  (% pf_a (holds a)
+  (% pf_b (holds b)
+  (: (holds (and a b))
+     (pf_and a b pf_a pf_b)))))))
+(check
+  (% a bool
+  (% b bool
+  (% pf_a (holds a)
+  (% pf_b (holds b)
+  (: (holds (and a b))
+     (pf_and _ _ pf_a pf_b)))))))

--- a/tests/tests/sugar_define_const.plf
+++ b/tests/tests/sugar_define_const.plf
@@ -1,0 +1,24 @@
+; Sorts and terms:
+(declare sort type)
+(declare term type)
+
+; Theory holds: term t holds, where t should have Boolean type
+(declare holds (! t term type))
+
+; function constructor :
+(declare arrow (! s1 sort (! s2 sort sort)))
+
+; high-order apply :
+(declare apply (! t1 term (! t2 term term)))
+
+; Booleans :
+(declare true term)
+(declare false term)
+
+; Negation
+(declare f_not term)
+(define-const not ((: t term)) (apply f_not t))
+
+; Conjunction
+(declare f_and term)
+(define-const and ((: t1 term) (: t2 term)) (apply (apply f_not t1) t2))

--- a/tests/tests/sugar_forall.plf
+++ b/tests/tests/sugar_forall.plf
@@ -2,4 +2,4 @@
 (declare tt bool)
 (declare ff bool)
 
-(declare holds (forall b bool type))
+(declare holds (pi b bool type))

--- a/tests/tests/sugar_forall.plf
+++ b/tests/tests/sugar_forall.plf
@@ -1,0 +1,5 @@
+(declare bool type)
+(declare tt bool)
+(declare ff bool)
+
+(declare holds (Forall b bool type))

--- a/tests/tests/sugar_forall.plf
+++ b/tests/tests/sugar_forall.plf
@@ -2,4 +2,4 @@
 (declare tt bool)
 (declare ff bool)
 
-(declare holds (Forall b bool type))
+(declare holds (forall b bool type))

--- a/tests/tests/sugar_lam.plf
+++ b/tests/tests/sugar_lam.plf
@@ -1,0 +1,20 @@
+(declare bool type)
+(declare tt bool)
+(declare ff bool)
+
+(declare holds (! b bool type))
+(declare impl (! a bool (! b bool bool)))
+(declare pf_impl (! hyp bool
+                 (! conc bool
+                 (! continuation (! pf_hyp (holds hyp) (holds conc))
+                 (holds (impl hyp conc))))))
+
+; without sugar
+(check (% b bool
+       (: (holds (impl b b))
+          (pf_impl b b (\ pf_b pf_b)))))
+
+; with sugar
+(check (% b bool
+       (: (holds (impl b b))
+          (pf_impl b b (lam pf_b pf_b)))))

--- a/tests/tests/sugar_let.plf
+++ b/tests/tests/sugar_let.plf
@@ -1,0 +1,20 @@
+(declare bool type)
+(declare tt bool)
+(declare ff bool)
+
+(declare holds (! b bool type))
+(declare impl (! a bool (! b bool bool)))
+(declare pf_impl (! hyp bool
+                 (! conc bool
+                 (! continuation (! pf_hyp (holds hyp) (holds conc))
+                 (holds (impl hyp conc))))))
+
+; without sugar
+(check (% b bool
+       (@ bb b
+       (: bool b))))
+
+; with sugar
+(check (% b bool
+       (let bb b
+       (: bool b))))

--- a/tests/tests/sugar_proved_by.plf
+++ b/tests/tests/sugar_proved_by.plf
@@ -1,0 +1,9 @@
+(declare bool type)
+(declare tt bool)
+(declare ff bool)
+
+(declare holds (! b bool type))
+
+(check (% b bool
+       (% b_pf (holds b)
+       (proved-by (holds b) b_pf))))

--- a/tests/tests/sugar_provided.plf
+++ b/tests/tests/sugar_provided.plf
@@ -1,0 +1,11 @@
+(declare bool type)
+(declare tt bool)
+(declare ff bool)
+
+(program bool_or ((a bool) (b bool)) bool
+         (match a
+                (tt tt)
+                (ff b)))
+
+(declare is_or (! a bool (! b bool (! sc (^ (bool_or a b) tt) type))))
+(declare is_or_2 (! a bool (! b bool (! sc (provided (bool_or a b) tt) type))))

--- a/tests/tests/sugar_skolem.plf
+++ b/tests/tests/sugar_skolem.plf
@@ -12,7 +12,7 @@
 (define-const = ((: t1 term) (: t2 term)) (apply (apply f_= t1) t2))
 (declare var (! v mpz (! s sort term)))
 (declare bvar (! v mpz (! s sort term)))
-(declare forall (! v mpz (! s sort term)))
+(declare forall_ (! v mpz (! s sort term)))
 (declare witness (! v mpz (! s sort term)))
 (declare map_to_witness (! k term (! w term type)))
 (declare Ok type)
@@ -40,7 +40,7 @@
                      (! v mpz
                      (! s sort
 		     (! goal term
-                     (! p (holds (not (apply (forall v s) body)))
+                     (! p (holds (not (apply (forall_ v s) body)))
 		     (! u (! v' mpz
 		          (! r (map_to_witness (var v' s) (apply (witness v s)
 		               (not body)))
@@ -52,7 +52,7 @@
                      (! s sort
                      (! bodyi term
 		     (! k term
-                     (! p (holds (not (apply (forall v s) body)))
+                     (! p (holds (not (apply (forall_ v s) body)))
 		     (! u (map_to_witness k (apply (witness v s) (not body)))
                      (! r (^ (substitute body v k) bodyi)
 		     (holds (not bodyi)))))))))))
@@ -63,7 +63,7 @@
 
 (check
 (% p1 (holds (not (= a b)))
-(% p2 (holds (not (apply (forall 7 U) (not (and (= a (bvar 7 U)) (= (bvar 7 U) b))))))
+(% p2 (holds (not (apply (forall_ 7 U) (not (and (= a (bvar 7 U)) (= (bvar 7 U) b))))))
 (: (holds false)
   (mk_skolemize _ _ _ _ p2 (\ v' (\ r
       (@ sko (skolemize _ _ _ _ _ p2 r)

--- a/tests/tests/sugar_skolem.plf
+++ b/tests/tests/sugar_skolem.plf
@@ -1,0 +1,74 @@
+(declare sort type)
+(declare term type)
+(declare holds (! t term type))
+(declare Bool sort)
+(declare apply (! t1 term (! t2 term term)))
+(declare false term)
+(declare f_not term)
+(define-const not ((: t term))  (apply f_not t))
+(declare f_and term)
+(define-const and ((: t1 term) (: t2 term)) (apply (apply f_and t1) t2))
+(declare f_=  term)
+(define-const = ((: t1 term) (: t2 term)) (apply (apply f_= t1) t2))
+(declare var (! v mpz (! s sort term)))
+(declare bvar (! v mpz (! s sort term)))
+(declare forall (! v mpz (! s sort term)))
+(declare witness (! v mpz (! s sort term)))
+(declare map_to_witness (! k term (! w term type)))
+(declare Ok type)
+(declare ok Ok)
+
+(declare contradiction (! f term (! p1 (holds f) (! p2 (holds (not f)) (holds false)))))
+(declare and_elim_1 (! f1 term (! f2 term (! p (holds (and f1 f2)) (holds f1)))))
+(declare and_elim_2 (! f1 term (! f2 term (! p (holds (and f1 f2)) (holds f2)))))
+(declare not_not_elim (! f term (! p (holds (not (not f))) (holds f))))
+
+(declare trans (! t1 term (! t2 term (! t3 term (! u1 (holds (= t1 t2)) (! u2 (holds (= t2 t3)) (holds (= t1 t3))))))))
+
+(program mpz_ifequal ((v1 mpz) (v mpz) (t term) (s term)) term (mp_ifzero (mp_add (mp_neg v1) v) t s) )
+
+(program substitute ((t term) (v mpz) (s term)) term
+  (match t
+    ((bvar v1 u1) 
+       (mpz_ifequal v v1 s t))
+    ((apply t1 t2) (apply (substitute t1 v s) (substitute t2 v s)))
+    (default t)
+  ))
+
+
+(declare mk_skolemize (! body term
+                     (! v mpz
+                     (! s sort
+		     (! goal term
+                     (! p (holds (not (apply (forall v s) body)))
+		     (! u (! v' mpz
+		          (! r (map_to_witness (var v' s) (apply (witness v s)
+		               (not body)))
+		     (holds goal)))
+		     (holds goal))))))))
+
+(declare skolemize (! body term
+                     (! v mpz
+                     (! s sort
+                     (! bodyi term
+		     (! k term
+                     (! p (holds (not (apply (forall v s) body)))
+		     (! u (map_to_witness k (apply (witness v s) (not body)))
+                     (! r (^ (substitute body v k) bodyi)
+		     (holds (not bodyi)))))))))))
+
+(declare U sort)
+(define a (var 1 U))
+(define b (var 2 U))
+
+(check
+(% p1 (holds (not (= a b)))
+(% p2 (holds (not (apply (forall 7 U) (not (and (= a (bvar 7 U)) (= (bvar 7 U) b))))))
+(: (holds false)
+  (mk_skolemize _ _ _ _ p2 (\ v' (\ r
+      (@ sko (skolemize _ _ _ _ _ p2 r)
+      (contradiction _ (trans _ _ _ 
+        (and_elim_1 _ _ (not_not_elim _ sko))
+        (and_elim_2 _ _ (not_not_elim _ sko )))
+    p1)))))))))
+

--- a/tests/tests/synext_declare_ty.plf
+++ b/tests/tests/synext_declare_ty.plf
@@ -1,0 +1,7 @@
+(declare-type bool)
+(declare tt bool)
+(declare ff bool)
+
+(declare-type holds bool)
+
+(declare pf_true (holds tt))

--- a/tests/tests/th_quant.plf
+++ b/tests/tests/th_quant.plf
@@ -1,5 +1,5 @@
 ; Deps: smt.plf th_base.plf
-(declare forall (! s sort
+(declare forall_ (! s sort
                    (! t (term s)
                       (! f formula
                          formula))))
@@ -46,8 +46,8 @@
                 ((= s t1 t2) (match fi
                                     ((= s ti1 ti2) (match (is_inst_t ti1 t1 k) (tt (is_inst_t ti2 t2 k)) (ff ff)))
                                     (default ff)))
-                ((forall s t1 f1) (match fi
-                                         ((forall s ti1 fi1) (is_inst_f fi1 f1 k))
+                ((forall_ s t1 f1) (match fi
+                                         ((forall_ s ti1 fi1) (is_inst_f fi1 f1 k))
                                          (default ff)))
                 (default ff)))
 
@@ -60,7 +60,7 @@
          (! s sort
             (! t (term s)
                (! f formula
-                  (! p (th_holds (not (forall s t f)))
+                  (! p (th_holds (not (forall_ s t f)))
                      (! u (! k (term s)
                              (! fi formula
                                 (! p1 (th_holds (not fi))
@@ -74,7 +74,7 @@
                (! f formula
                   (! k (term s)
                      (! fi formula
-                        (! p (th_holds (forall s t f))
+                        (! p (th_holds (forall_ s t f))
                            (! r (^ (is_inst fi f t k) tt)
                               (! u (! p1 (th_holds fi)
                                       (holds cln))


### PR DESCRIPTION
Implements the following syntax extensions:
* Declaration lists are used in a few places: they are a list of arguments
   that can be named ((: NAME TYPE)) or anonymous (TYPE).
* New type can be declared with (declare-type NAME DECL_LIST), e.g.
   (declare-types holds (bool))
* New rules can be declared with (declare-rule NAME DECL_LIST RESULT), see
   below for an example.
* New functions can be defined with (declare-const NAME DECL_LIST RESULT),
   e.g. (define-const and ((: a bool) (: b bool)) (apply (apply and_fn a) b))
* Function types can be written as (-> DECL_LIST RESULT)
* Proofs are checked using (check-assuming DECL_LIST TYPE TERM), where
  DECL_LIST introduces assumptions, TYPE represents the proposition, and
  TERM represents the proof.
* Deprecate %: the symbol for assumptions. % was only valid immediately
   inside check commands, and is subsumed by the check-assuming command.
* provided is an alias for the side-condition invoking ^ symbol
* let is an alias for the let-binding @ symbol
* Forall is an alias for !, the dependent function type symbol.
* lam is an alias for \, the un-annotated lambda symbol.

Implementation changes:
* gave the token stream an additional lookahead space.
* Add a few helper functions for checking declaration lists and building macros.