### PR TITLE
Change expected output

### DIFF
--- a/src/check.cpp
+++ b/src/check.cpp
@@ -1084,8 +1084,6 @@ std::pair<Expr*, Expr*> build_macro(std::vector<std::pair<Expr*, Expr*>>&& args,
   return {ret, ret_ty};
 }
 
-int check_time;
-
 void check_file(const char* _filename, args a, sccwriter* scw)
 {
   std::ifstream fs;

--- a/src/check.h
+++ b/src/check.h
@@ -31,8 +31,6 @@ typedef struct args
   bool use_nested_app;
 } args;
 
-extern int check_time;
-
 class sccwriter;
 class libwriter;
 

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -172,7 +172,6 @@ Expr *read_code()
             std::cout << "Can't make IFMARKED with index = " << index
                       << std::endl;
           }
-          Expr::markedCount++;
           eat_token(Token::Close);
           return ret;
         }
@@ -213,7 +212,6 @@ Expr *read_code()
             std::cout << "Can't make MARKVAR with index = " << index
                       << std::endl;
           }
-          Expr::markedCount++;
           eat_token(Token::Close);
           return ret;
         }

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -10,7 +10,6 @@
 using namespace std;
 
 int HoleExpr::next_id = 0;
-int Expr::markedCount = 0;
 // Maximum reference count, 2^22-1
 int Expr::d_maxRefCount = 4194303;
 
@@ -1046,12 +1045,10 @@ bool Expr::isType(Expr *statType)
   return true;
 }
 
-int SymExpr::symmCount = 0;
 int SymExpr::mark()
 {
   if (mark_map.find(this) == mark_map.end())
   {
-    symmCount++;
     mark_map[this] = 0;
   }
   return mark_map[this];

--- a/src/expr.h
+++ b/src/expr.h
@@ -119,7 +119,6 @@ class Expr
  public:
   virtual ~Expr() {}
 
-  static int markedCount;
   inline Expr *followDefs();
   inline int getclass() const { return data & 7; }
   int getexmark() const { return data & 256; }
@@ -342,7 +341,6 @@ class SymExpr : public Expr
 {
  public:
   Expr *val;  // may be set by beta-reduction and clone().
-  static int symmCount;
 
   SymExpr(std::string _s, int theclass = SYM_EXPR) : Expr(theclass, 0), val(0)
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,8 +102,6 @@ int main(int argc, char **argv)
 
   init();
 
-  check_time = (int)clock();
-
   if (a.files.size())
   {
     sccwriter *scw = NULL;
@@ -135,9 +133,6 @@ int main(int argc, char **argv)
   cleanup();
   a.files.clear();
 #endif
-
-  //std::cout << "Proof checked successfully!" << std::endl << std::endl;
-  //std::cout << "time = " << (int)clock() - check_time << std::endl;
-  //std::cout << "sym count = " << SymExpr::symmCount << std::endl;
-  //std::cout << "marked count = " << Expr::markedCount << std::endl;
+  
+  // older versions printed "Proof checked successfully!" here
 }


### PR DESCRIPTION
We now print `success` for each successful `check` command, with no other output.

Fixes https://github.com/cvc5/LFSC/issues/79.